### PR TITLE
chore(deps/vue): bump to 3.15.17 from 3.5.16

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-primeui": "^0.3.4",
     "tinycolor2": "^1.6.0",
-    "vue": "^3.4.29",
+    "vue": "^3.5.17",
     "vue-codemirror": "^6.1.1",
     "vue-router": "^4.0.13"
   },

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 4.17.17
       '@vueuse/core':
         specifier: ^11.1.0
-        version: 11.3.0(vue@3.5.16(typescript@5.4.5))
+        version: 11.3.0(vue@3.5.17(typescript@5.4.5))
       codemirror:
         specifier: ^6.0.1
         version: 6.0.1
@@ -46,7 +46,7 @@ importers:
         version: 14.5.2
       primevue:
         specifier: ^4.2.4
-        version: 4.3.4(vue@3.5.16(typescript@5.4.5))
+        version: 4.3.4(vue@3.5.17(typescript@5.4.5))
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
@@ -60,14 +60,14 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       vue:
-        specifier: ^3.4.29
-        version: 3.5.16(typescript@5.4.5)
+        specifier: ^3.5.17
+        version: 3.5.17(typescript@5.4.5)
       vue-codemirror:
         specifier: ^6.1.1
-        version: 6.1.1(codemirror@6.0.1)(vue@3.5.16(typescript@5.4.5))
+        version: 6.1.1(codemirror@6.0.1)(vue@3.5.17(typescript@5.4.5))
       vue-router:
         specifier: ^4.0.13
-        version: 4.5.1(vue@3.5.16(typescript@5.4.5))
+        version: 4.5.1(vue@3.5.17(typescript@5.4.5))
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^4.0.0
@@ -83,7 +83,7 @@ importers:
         version: 9.0.3(@types/react@19.1.6)(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))
       '@storybook/vue3-vite':
         specifier: ^9.0.1
-        version: 9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vite@5.4.19(@types/node@20.17.57))(vue@3.5.16(typescript@5.4.5))
+        version: 9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vite@5.4.19(@types/node@20.17.57))(vue@3.5.17(typescript@5.4.5))
       '@tsconfig/node20':
         specifier: ^20.1.4
         version: 20.1.5
@@ -101,7 +101,7 @@ importers:
         version: 8.33.0(eslint@9.28.0(jiti@1.21.7))(typescript@5.4.5)
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
-        version: 5.2.4(vite@5.4.19(@types/node@20.17.57))(vue@3.5.16(typescript@5.4.5))
+        version: 5.2.4(vite@5.4.19(@types/node@20.17.57))(vue@3.5.17(typescript@5.4.5))
       '@vitest/browser':
         specifier: ^2.1.9
         version: 2.1.9(@types/node@20.17.57)(playwright@1.52.0)(typescript@5.4.5)(vite@5.4.19(@types/node@20.17.57))(vitest@2.1.9)
@@ -201,12 +201,21 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.27.4':
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.3':
     resolution: {integrity: sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.1':
+    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
     engines: {node: '>=6.9.0'}
 
   '@bundled-es-modules/cookie@2.0.1':
@@ -1105,14 +1114,26 @@ packages:
   '@vue/compiler-core@3.5.16':
     resolution: {integrity: sha512-AOQS2eaQOaaZQoL1u+2rCJIKDruNXVBZSiUD3chnUrsoX5ZTQMaCvXlWNIfxBJuU15r1o7+mpo5223KVtIhAgQ==}
 
+  '@vue/compiler-core@3.5.17':
+    resolution: {integrity: sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==}
+
   '@vue/compiler-dom@3.5.16':
     resolution: {integrity: sha512-SSJIhBr/teipXiXjmWOVWLnxjNGo65Oj/8wTEQz0nqwQeP75jWZ0n4sF24Zxoht1cuJoWopwj0J0exYwCJ0dCQ==}
+
+  '@vue/compiler-dom@3.5.17':
+    resolution: {integrity: sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==}
 
   '@vue/compiler-sfc@3.5.16':
     resolution: {integrity: sha512-rQR6VSFNpiinDy/DVUE0vHoIDUF++6p910cgcZoaAUm3POxgNOOdS/xgoll3rNdKYTYPnnbARDCZOyZ+QSe6Pw==}
 
+  '@vue/compiler-sfc@3.5.17':
+    resolution: {integrity: sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==}
+
   '@vue/compiler-ssr@3.5.16':
     resolution: {integrity: sha512-d2V7kfxbdsjrDSGlJE7my1ZzCXViEcqN6w14DOsDrUCHEA6vbnVCpRFfrc4ryCP/lCKzX2eS1YtnLE/BuC9f/A==}
+
+  '@vue/compiler-ssr@3.5.17':
+    resolution: {integrity: sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -1128,22 +1149,25 @@ packages:
       typescript:
         optional: true
 
-  '@vue/reactivity@3.5.16':
-    resolution: {integrity: sha512-FG5Q5ee/kxhIm1p2bykPpPwqiUBV3kFySsHEQha5BJvjXdZTUfmya7wP7zC39dFuZAcf/PD5S4Lni55vGLMhvA==}
+  '@vue/reactivity@3.5.17':
+    resolution: {integrity: sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==}
 
-  '@vue/runtime-core@3.5.16':
-    resolution: {integrity: sha512-bw5Ykq6+JFHYxrQa7Tjr+VSzw7Dj4ldR/udyBZbq73fCdJmyy5MPIFR9IX/M5Qs+TtTjuyUTCnmK3lWWwpAcFQ==}
+  '@vue/runtime-core@3.5.17':
+    resolution: {integrity: sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==}
 
-  '@vue/runtime-dom@3.5.16':
-    resolution: {integrity: sha512-T1qqYJsG2xMGhImRUV9y/RseB9d0eCYZQ4CWca9ztCuiPj/XWNNN+lkNBuzVbia5z4/cgxdL28NoQCvC0Xcfww==}
+  '@vue/runtime-dom@3.5.17':
+    resolution: {integrity: sha512-8El0M60TcwZ1QMz4/os2MdlQECgGoVHPuLnQBU3m9h3gdNRW9xRmI8iLS4t/22OQlOE6aJvNNlBiCzPHur4H9g==}
 
-  '@vue/server-renderer@3.5.16':
-    resolution: {integrity: sha512-BrX0qLiv/WugguGsnQUJiYOE0Fe5mZTwi6b7X/ybGB0vfrPH9z0gD/Y6WOR1sGCgX4gc25L1RYS5eYQKDMoNIg==}
+  '@vue/server-renderer@3.5.17':
+    resolution: {integrity: sha512-BOHhm8HalujY6lmC3DbqF6uXN/K00uWiEeF22LfEsm9Q93XeJ/plHTepGwf6tqFcF7GA5oGSSAAUock3VvzaCA==}
     peerDependencies:
-      vue: 3.5.16
+      vue: 3.5.17
 
   '@vue/shared@3.5.16':
     resolution: {integrity: sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==}
+
+  '@vue/shared@3.5.17':
+    resolution: {integrity: sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==}
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
@@ -2257,6 +2281,10 @@ packages:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2824,8 +2852,8 @@ packages:
     peerDependencies:
       typescript: '>=5.0.0'
 
-  vue@3.5.16:
-    resolution: {integrity: sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==}
+  vue@3.5.17:
+    resolution: {integrity: sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2985,9 +3013,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.3
 
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.1
+
   '@babel/runtime@7.27.4': {}
 
   '@babel/types@7.27.3':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.28.1':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -3430,16 +3467,16 @@ snapshots:
 
   '@primeuix/utils@0.5.3': {}
 
-  '@primevue/core@4.3.4(vue@3.5.16(typescript@5.4.5))':
+  '@primevue/core@4.3.4(vue@3.5.17(typescript@5.4.5))':
     dependencies:
       '@primeuix/styled': 0.6.4
       '@primeuix/utils': 0.5.3
-      vue: 3.5.16(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
 
-  '@primevue/icons@4.3.4(vue@3.5.16(typescript@5.4.5))':
+  '@primevue/icons@4.3.4(vue@3.5.17(typescript@5.4.5))':
     dependencies:
       '@primeuix/utils': 0.5.3
-      '@primevue/core': 4.3.4(vue@3.5.16(typescript@5.4.5))
+      '@primevue/core': 4.3.4(vue@3.5.17(typescript@5.4.5))
     transitivePeerDependencies:
       - vue
 
@@ -3549,26 +3586,26 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3)
 
-  '@storybook/vue3-vite@9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vite@5.4.19(@types/node@20.17.57))(vue@3.5.16(typescript@5.4.5))':
+  '@storybook/vue3-vite@9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vite@5.4.19(@types/node@20.17.57))(vue@3.5.17(typescript@5.4.5))':
     dependencies:
       '@storybook/builder-vite': 9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vite@5.4.19(@types/node@20.17.57))
-      '@storybook/vue3': 9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.16(typescript@5.4.5))
+      '@storybook/vue3': 9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.17(typescript@5.4.5))
       find-package-json: 1.2.0
       magic-string: 0.30.17
       storybook: 9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3)
       typescript: 5.8.3
       vite: 5.4.19(@types/node@20.17.57)
       vue-component-meta: 2.2.10(typescript@5.8.3)
-      vue-docgen-api: 4.79.2(vue@3.5.16(typescript@5.4.5))
+      vue-docgen-api: 4.79.2(vue@3.5.17(typescript@5.4.5))
     transitivePeerDependencies:
       - vue
 
-  '@storybook/vue3@9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.16(typescript@5.4.5))':
+  '@storybook/vue3@9.0.3(storybook@9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3))(vue@3.5.17(typescript@5.4.5))':
     dependencies:
       '@storybook/global': 5.0.0
       storybook: 9.0.3(@testing-library/dom@10.4.0)(prettier@3.5.3)
       type-fest: 2.19.0
-      vue: 3.5.16(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
       vue-component-type-helpers: 3.0.1
 
   '@testing-library/dom@10.4.0':
@@ -3718,10 +3755,10 @@ snapshots:
       '@typescript-eslint/types': 8.33.0
       eslint-visitor-keys: 4.2.0
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@20.17.57))(vue@3.5.16(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@20.17.57))(vue@3.5.17(typescript@5.4.5))':
     dependencies:
       vite: 5.4.19(@types/node@20.17.57)
-      vue: 3.5.16(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
 
   '@vitest/browser@2.1.9(@types/node@20.17.57)(playwright@1.52.0)(typescript@5.4.5)(vite@5.4.19(@types/node@20.17.57))(vitest@2.1.9)':
     dependencies:
@@ -3826,10 +3863,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.17':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@vue/shared': 3.5.17
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.16':
     dependencies:
       '@vue/compiler-core': 3.5.16
       '@vue/shared': 3.5.16
+
+  '@vue/compiler-dom@3.5.17':
+    dependencies:
+      '@vue/compiler-core': 3.5.17
+      '@vue/shared': 3.5.17
 
   '@vue/compiler-sfc@3.5.16':
     dependencies:
@@ -3843,10 +3893,27 @@ snapshots:
       postcss: 8.5.4
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.17':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@vue/compiler-core': 3.5.17
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-ssr': 3.5.17
+      '@vue/shared': 3.5.17
+      estree-walker: 2.0.2
+      magic-string: 0.30.17
+      postcss: 8.5.6
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.16':
     dependencies:
       '@vue/compiler-dom': 3.5.16
       '@vue/shared': 3.5.16
+
+  '@vue/compiler-ssr@3.5.17':
+    dependencies:
+      '@vue/compiler-dom': 3.5.17
+      '@vue/shared': 3.5.17
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -3881,29 +3948,31 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@vue/reactivity@3.5.16':
+  '@vue/reactivity@3.5.17':
     dependencies:
-      '@vue/shared': 3.5.16
+      '@vue/shared': 3.5.17
 
-  '@vue/runtime-core@3.5.16':
+  '@vue/runtime-core@3.5.17':
     dependencies:
-      '@vue/reactivity': 3.5.16
-      '@vue/shared': 3.5.16
+      '@vue/reactivity': 3.5.17
+      '@vue/shared': 3.5.17
 
-  '@vue/runtime-dom@3.5.16':
+  '@vue/runtime-dom@3.5.17':
     dependencies:
-      '@vue/reactivity': 3.5.16
-      '@vue/runtime-core': 3.5.16
-      '@vue/shared': 3.5.16
+      '@vue/reactivity': 3.5.17
+      '@vue/runtime-core': 3.5.17
+      '@vue/shared': 3.5.17
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.16(vue@3.5.16(typescript@5.4.5))':
+  '@vue/server-renderer@3.5.17(vue@3.5.17(typescript@5.4.5))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.16
-      '@vue/shared': 3.5.16
-      vue: 3.5.16(typescript@5.4.5)
+      '@vue/compiler-ssr': 3.5.17
+      '@vue/shared': 3.5.17
+      vue: 3.5.17(typescript@5.4.5)
 
   '@vue/shared@3.5.16': {}
+
+  '@vue/shared@3.5.17': {}
 
   '@vue/test-utils@2.4.6':
     dependencies:
@@ -3912,21 +3981,21 @@ snapshots:
 
   '@vue/tsconfig@0.5.1': {}
 
-  '@vueuse/core@11.3.0(vue@3.5.16(typescript@5.4.5))':
+  '@vueuse/core@11.3.0(vue@3.5.17(typescript@5.4.5))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.3.0
-      '@vueuse/shared': 11.3.0(vue@3.5.16(typescript@5.4.5))
-      vue-demi: 0.14.10(vue@3.5.16(typescript@5.4.5))
+      '@vueuse/shared': 11.3.0(vue@3.5.17(typescript@5.4.5))
+      vue-demi: 0.14.10(vue@3.5.17(typescript@5.4.5))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
   '@vueuse/metadata@11.3.0': {}
 
-  '@vueuse/shared@11.3.0(vue@3.5.16(typescript@5.4.5))':
+  '@vueuse/shared@11.3.0(vue@3.5.17(typescript@5.4.5))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.16(typescript@5.4.5))
+      vue-demi: 0.14.10(vue@3.5.17(typescript@5.4.5))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -5021,6 +5090,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.2.1: {}
 
   prettier@3.5.3: {}
@@ -5031,13 +5106,13 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  primevue@4.3.4(vue@3.5.16(typescript@5.4.5)):
+  primevue@4.3.4(vue@3.5.17(typescript@5.4.5)):
     dependencies:
       '@primeuix/styled': 0.6.4
       '@primeuix/styles': 1.1.1
       '@primeuix/utils': 0.5.3
-      '@primevue/core': 4.3.4(vue@3.5.16(typescript@5.4.5))
-      '@primevue/icons': 4.3.4(vue@3.5.16(typescript@5.4.5))
+      '@primevue/core': 4.3.4(vue@3.5.17(typescript@5.4.5))
+      '@primevue/icons': 4.3.4(vue@3.5.17(typescript@5.4.5))
     transitivePeerDependencies:
       - vue
 
@@ -5564,14 +5639,14 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-codemirror@6.1.1(codemirror@6.0.1)(vue@3.5.16(typescript@5.4.5)):
+  vue-codemirror@6.1.1(codemirror@6.0.1)(vue@3.5.17(typescript@5.4.5)):
     dependencies:
       '@codemirror/commands': 6.8.1
       '@codemirror/language': 6.11.0
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.37.1
       codemirror: 6.0.1
-      vue: 3.5.16(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
 
   vue-component-meta@2.2.10(typescript@5.8.3):
     dependencies:
@@ -5586,11 +5661,11 @@ snapshots:
 
   vue-component-type-helpers@3.0.1: {}
 
-  vue-demi@0.14.10(vue@3.5.16(typescript@5.4.5)):
+  vue-demi@0.14.10(vue@3.5.17(typescript@5.4.5)):
     dependencies:
-      vue: 3.5.16(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
 
-  vue-docgen-api@4.79.2(vue@3.5.16(typescript@5.4.5)):
+  vue-docgen-api@4.79.2(vue@3.5.17(typescript@5.4.5)):
     dependencies:
       '@babel/parser': 7.27.4
       '@babel/types': 7.27.3
@@ -5603,8 +5678,8 @@ snapshots:
       pug: 3.0.3
       recast: 0.23.11
       ts-map: 1.0.3
-      vue: 3.5.16(typescript@5.4.5)
-      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.16(typescript@5.4.5))
+      vue: 3.5.17(typescript@5.4.5)
+      vue-inbrowser-compiler-independent-utils: 4.71.1(vue@3.5.17(typescript@5.4.5))
 
   vue-eslint-parser@9.4.3(eslint@9.28.0(jiti@1.21.7)):
     dependencies:
@@ -5619,14 +5694,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.16(typescript@5.4.5)):
+  vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.17(typescript@5.4.5)):
     dependencies:
-      vue: 3.5.16(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
 
-  vue-router@4.5.1(vue@3.5.16(typescript@5.4.5)):
+  vue-router@4.5.1(vue@3.5.17(typescript@5.4.5)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.16(typescript@5.4.5)
+      vue: 3.5.17(typescript@5.4.5)
 
   vue-tsc@2.2.10(typescript@5.4.5):
     dependencies:
@@ -5634,13 +5709,13 @@ snapshots:
       '@vue/language-core': 2.2.10(typescript@5.4.5)
       typescript: 5.4.5
 
-  vue@3.5.16(typescript@5.4.5):
+  vue@3.5.17(typescript@5.4.5):
     dependencies:
-      '@vue/compiler-dom': 3.5.16
-      '@vue/compiler-sfc': 3.5.16
-      '@vue/runtime-dom': 3.5.16
-      '@vue/server-renderer': 3.5.16(vue@3.5.16(typescript@5.4.5))
-      '@vue/shared': 3.5.16
+      '@vue/compiler-dom': 3.5.17
+      '@vue/compiler-sfc': 3.5.17
+      '@vue/runtime-dom': 3.5.17
+      '@vue/server-renderer': 3.5.17(vue@3.5.17(typescript@5.4.5))
+      '@vue/shared': 3.5.17
     optionalDependencies:
       typescript: 5.4.5
 


### PR DESCRIPTION
<!-- PR_SUMMARY_START -->
- chore(deps/vue): bump to 3.15.17 from 3.5.16

  It is not clear reading package.json that project is using latest version of Vue
<!-- PR_SUMMARY_END -->

https://github.com/vuejs/core/blob/main/CHANGELOG.md#3517-2025-06-18 just includes some bug fixes from 3.5.16. 

---

I was reading https://vuejs.org/guide/typescript/composition-api.html#typing-component-props and https://blog.vuejs.org/posts/vue-3-5 and found out this snippet:
https://github.com/Yonava/magic-graphs/blob/e61e3141d0711a583e430d54d5220612c66455ff/client/src/ui/core/toolbar/ToolbarHint.vue#L6-L14

Could be updated to use latest and greatest syntax, which is easier to read... but I was not sure I could use this reading package.json. This PR makes it clear project is indeed already on 3.5.*.