### PR TITLE
feat(workflows): setup

### DIFF
--- a/client/.github/workflows/ci-client.yaml
+++ b/client/.github/workflows/ci-client.yaml
@@ -1,0 +1,23 @@
+name: CI
+on:
+ pull_request:
+jobs:
+ check:
+   runs-on: ubuntu-22.04
+   steps:
+     - uses: actions/checkout@v4
+     - name: Install Node
+       uses: actions/setup-node@v4
+       with:
+         node-version: 'lts/*'
+         cache: 'pnpm'
+     - name: Install pnpm
+       uses: pnpm/action-setup@v4
+       with:
+         version: latest
+     - name: Install dependencies
+       run: pnpm install --frozen-lockfile
+       working-directory: ./client
+     - name: Run check
+       run: pnpm run check
+       working-directory: ./client

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "build:js": "vite build",
     "build:storybook": "storybook build",
     "build:types": "vue-tsc --build --force",
-    "check": "run-p build:types build:js format:check",
+    "check": "format:check",
     "preview": "vite preview",
     "format": "prettier --cache --write .",
     "format:check": "prettier --cache --check .",


### PR DESCRIPTION

<!-- PR_SUMMARY_START -->
- feat(workflows): setup

  Basic format checking on PRs. More strict checks to come after type and
  build checks are passing.

---

previous pr: [#521](https://github.com/Yonava/magic-graphs/pull/521)
<!-- PR_SUMMARY_END -->

Normally, you would see these checks already start running. I am confused why these are not yet runing on this pr. I think this is permissions issue :shrug: .

I believe this ci setup should work, but I think admin may need to approve this somehow.