### PR TITLE
[shapes] feat: offscreen canvas compositing for group-aware text area rendering

### DIFF
--- a/packages/graph/src/plugins/canvas/index.ts
+++ b/packages/graph/src/plugins/canvas/index.ts
@@ -133,10 +133,10 @@ export const useCanvasPlugin = <
           shape,
           id: edge.id,
           graphType: 'edge',
+          priority: 1,
         } as const;
       })
-      .filter(Boolean)
-      .map((item, i) => ({ ...item!, priority: i * 10 }));
+      .filter((el) => !!el);
 
     const nodeCanvasElements = graph.nodes.value
       .map((node) => {
@@ -151,6 +151,7 @@ export const useCanvasPlugin = <
           shape,
           id: node.id,
           graphType: 'node',
+          priority: 2,
           data: {
             [CANVAS_ELEMENT_CURSOR_FIELD_KEY]: resolveToken(
               'node.default.cursor',
@@ -159,8 +160,7 @@ export const useCanvasPlugin = <
           },
         } as const;
       })
-      .filter(Boolean)
-      .map((item, i) => ({ ...item!, priority: i * 10 + 1000 }));
+      .filter((el) => !!el);
 
     aggregator.push(...edgeCanvasElements);
     aggregator.push(...nodeCanvasElements);

--- a/packages/graph/src/plugins/canvas/themes/presets/shared/edge.ts
+++ b/packages/graph/src/plugins/canvas/themes/presets/shared/edge.ts
@@ -107,7 +107,7 @@ const edgeShape: GraphTheme['edge']['default']['shape'] = (edge, graph) => {
   const canvasColor = graph.resolveToken('canvas.color');
 
   const textAreaOnEdge: TextArea = {
-    color: canvasColor,
+    color: 'transparent',
     activeColor: canvasColor,
     textBlock: {
       content: styles.text,

--- a/packages/graph/src/plugins/canvas/themes/presets/shared/edge.ts
+++ b/packages/graph/src/plugins/canvas/themes/presets/shared/edge.ts
@@ -107,7 +107,7 @@ const edgeShape: GraphTheme['edge']['default']['shape'] = (edge, graph) => {
   const canvasColor = graph.resolveToken('canvas.color');
 
   const textAreaOnEdge: TextArea = {
-    color: 'transparent',
+    color: 'none',
     activeColor: canvasColor,
     textBlock: {
       content: styles.text,

--- a/packages/graph/src/plugins/canvas/themes/presets/shared/node.ts
+++ b/packages/graph/src/plugins/canvas/themes/presets/shared/node.ts
@@ -22,13 +22,13 @@ const nodeCircle: GraphTheme['node']['default']['shape'] = (node, graph) => {
       lineWidth: styles.borderWidth,
     },
     textArea: {
+      color: colors.TRANSPARENT,
       textBlock: {
         content: styles.text,
         fontSize: styles.textSize,
         fontWeight: styles.textFontWeight,
         color: styles.textColor,
       },
-      color: colors.TRANSPARENT,
     },
   });
 };

--- a/packages/graph/src/plugins/canvas/useAggregator.ts
+++ b/packages/graph/src/plugins/canvas/useAggregator.ts
@@ -30,26 +30,7 @@ export const useAggregator = ({
   const draw = (ctx: CanvasRenderingContext2D) => {
     updateAggregator();
 
-    const indexOfLastEdge = aggregator.value.findLastIndex(
-      (item) => item.graphType === 'edge',
-    );
-
-    const beforeLastEdge = aggregator.value.slice(0, indexOfLastEdge + 1);
-    const afterLastEdge = aggregator.value.slice(indexOfLastEdge + 1);
-
-    for (const item of beforeLastEdge) {
-      item.shape.drawShape(ctx);
-    }
-
-    for (const item of beforeLastEdge) {
-      item.shape.drawTextAreaMatte?.(ctx);
-    }
-
-    for (const item of beforeLastEdge) {
-      item.shape.drawText?.(ctx);
-    }
-
-    for (const item of afterLastEdge) {
+    for (const item of aggregator.value) {
       item.shape.draw(ctx);
     }
 

--- a/packages/graph/src/plugins/canvas/useAggregator.ts
+++ b/packages/graph/src/plugins/canvas/useAggregator.ts
@@ -1,3 +1,4 @@
+import { drawGroup } from '@magic/shapes/drawGroup';
 import type { Coordinate } from '@magic/shapes/types/utility';
 
 import { ref } from 'vue';
@@ -27,11 +28,24 @@ export const useAggregator = ({
     ];
   };
 
+  const groupByPriority = (elements: Aggregator): Map<number, Aggregator> => {
+    const groups = new Map<number, Aggregator>();
+    for (const item of elements) {
+      const group = groups.get(item.priority) ?? [];
+      group.push(item);
+      groups.set(item.priority, group);
+    }
+    return groups;
+  };
+
   const draw = (ctx: CanvasRenderingContext2D) => {
     updateAggregator();
 
-    for (const item of aggregator.value) {
-      item.shape.draw(ctx);
+    for (const group of groupByPriority(aggregator.value).values()) {
+      drawGroup(
+        ctx,
+        group.map((item) => item.shape),
+      );
     }
 
     emit('onDraw', ctx);

--- a/packages/products/src/shape-playground/ShapePlayground.vue
+++ b/packages/products/src/shape-playground/ShapePlayground.vue
@@ -67,7 +67,13 @@
     id: 'something',
     end: { x: 500, y: 500 },
     start: { x: 100, y: 200 },
-    dash: [20, 20],
+    textArea: {
+      color: 'transparent',
+      textBlock: {
+        color: 'red',
+        content: 'Hello',
+      },
+    },
   });
 
   const cir2 = shapes.circle({

--- a/packages/shapes/src/drawGroup.ts
+++ b/packages/shapes/src/drawGroup.ts
@@ -1,0 +1,79 @@
+import type { Shape } from './types/index.ts';
+
+/**
+ * Creates an offscreen canvas that mirrors the main canvas's pixel dimensions
+ * and has the same camera transform applied, ready for isolated drawing.
+ */
+const createOffscreenCanvas = (ctx: CanvasRenderingContext2D): CanvasRenderingContext2D => {
+  const offscreen = document.createElement('canvas');
+  offscreen.width = ctx.canvas.width;
+  offscreen.height = ctx.canvas.height;
+
+  const offCtx = offscreen.getContext('2d')!;
+  offCtx.setTransform(ctx.getTransform());
+
+  return offCtx;
+};
+
+/**
+ * Composites the offscreen canvas onto the main canvas.
+ * Transform is reset so offscreen pixels map 1:1 to main canvas pixels.
+ */
+const compositeToMain = (ctx: CanvasRenderingContext2D, offCtx: CanvasRenderingContext2D) => {
+  ctx.save();
+  ctx.resetTransform();
+  ctx.drawImage(offCtx.canvas, 0, 0);
+  ctx.restore();
+};
+
+/**
+ * Draws a group of shapes with their text areas cleanly layered on top,
+ * using a single shared offscreen canvas to handle compositing correctly
+ * even when shapes cross each other's text areas.
+ *
+ * ## Why this is necessary
+ *
+ * When shapes are drawn independently, each shape's text area matte covers
+ * whatever was drawn before it — including lines from other shapes crossing
+ * through that text area. For straight edges on a graph this is especially
+ * visible: a crossing edge gets cut off at the text label boundary.
+ *
+ * ## How it works
+ *
+ * 1. All shapes are drawn to a single offscreen canvas.
+ * 2. Every text area is punched transparent using `destination-out` compositing.
+ *    Because all shapes share the same offscreen canvas, a crossing edge's
+ *    line is already present when the hole is punched — it gets erased along
+ *    with the label's own edge, leaving clean transparency.
+ * 3. The offscreen canvas is composited onto the main canvas. Whatever was
+ *    drawn beneath (background pattern, shapes outside the group) shows through
+ *    the transparent holes naturally.
+ * 4. Text labels are drawn directly on the main canvas on top of everything.
+ *
+ * @param ctx - The main canvas rendering context
+ * @param shapes - Shapes to draw as a group (e.g. all edges on a graph)
+ */
+export const drawGroup = (ctx: CanvasRenderingContext2D, shapes: Shape[]) => {
+  if (shapes.length === 0) return;
+
+  const offCtx = createOffscreenCanvas(ctx);
+
+  for (const shape of shapes) {
+    shape.drawShape(offCtx);
+  }
+
+  offCtx.globalCompositeOperation = 'destination-out';
+  for (const shape of shapes) {
+    shape.drawTextAreaHole?.(offCtx);
+  }
+
+  compositeToMain(ctx, offCtx);
+
+  for (const shape of shapes) {
+    if (shape.drawTextAreaHole) {
+      shape.drawText?.(ctx);
+    } else {
+      shape.drawTextArea?.(ctx);
+    }
+  }
+};

--- a/packages/shapes/src/shapes/arrow/index.ts
+++ b/packages/shapes/src/shapes/arrow/index.ts
@@ -20,9 +20,9 @@ export const arrow: ShapeFactory<ArrowSchema> = (options) => {
   const schema = resolveArrowDefaults(options);
 
   const anchorPt = getTextAreaAnchorPoint(schema);
-  const text = getShapeTextProps(anchorPt, schema.textArea);
-
   const drawShape = drawArrowWithCtx(schema);
+  const text = getShapeTextProps(anchorPt, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
 
   const shapeHitbox = arrowHitbox(schema);
   const efficientHitbox = arrowEfficientHitbox(schema);
@@ -31,10 +31,10 @@ export const arrow: ShapeFactory<ArrowSchema> = (options) => {
 
   const getBoundingBox = getArrowBoundingBox(schema);
 
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   return shapeFactoryWrapper({
     name: 'arrow',
@@ -48,6 +48,6 @@ export const arrow: ShapeFactory<ArrowSchema> = (options) => {
     efficientHitbox,
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/cross/index.ts
+++ b/packages/shapes/src/shapes/cross/index.ts
@@ -17,13 +17,13 @@ export const cross: ShapeFactory<CrossSchema> = (options) => {
   }
 
   const schema = resolveCrossDefaults(options);
-  const text = getShapeTextProps(schema.at, schema.textArea);
-
   const drawShape = drawCrossWithCtx(schema);
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const text = getShapeTextProps(schema.at, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   const shapeHitbox = crossHitbox(schema);
   const efficientHitbox = crossEfficientHitbox(schema);
@@ -44,6 +44,6 @@ export const cross: ShapeFactory<CrossSchema> = (options) => {
     efficientHitbox,
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/ellipse/index.ts
+++ b/packages/shapes/src/shapes/ellipse/index.ts
@@ -17,9 +17,9 @@ export const ellipse: ShapeFactory<EllipseSchema> = (options) => {
   }
 
   const schema = resolveEllipseDefaults(options);
-  const text = getShapeTextProps(schema.at, schema.textArea);
-
   const drawShape = drawEllipseWithCtx(schema);
+  const text = getShapeTextProps(schema.at, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
   const shapeHitbox = ellipseHitbox(schema);
 
   const efficientHitbox = ellipseEfficientHitbox(schema);
@@ -28,10 +28,10 @@ export const ellipse: ShapeFactory<EllipseSchema> = (options) => {
 
   const getBoundingBox = getEllipseBoundingBox(schema);
 
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   return shapeFactoryWrapper({
     name: 'ellipse',
@@ -46,6 +46,6 @@ export const ellipse: ShapeFactory<EllipseSchema> = (options) => {
     efficientHitbox,
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/line/index.ts
+++ b/packages/shapes/src/shapes/line/index.ts
@@ -20,7 +20,9 @@ export const line: ShapeFactory<LineSchema> = (options) => {
   const schema = resolveLineDefaults(options);
 
   const anchorPt = getTextAreaAnchorPoint(schema);
-  const text = getShapeTextProps(anchorPt, schema.textArea);
+  const drawShape = drawLineWithCtx(schema);
+  const text = getShapeTextProps(anchorPt, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
 
   const shapeHitbox = lineHitbox(schema);
   const efficientHitbox = lineEfficientHitbox(schema);
@@ -29,11 +31,10 @@ export const line: ShapeFactory<LineSchema> = (options) => {
 
   const getBoundingBox = getLineBoundingBox(schema);
 
-  const drawShape = drawLineWithCtx(schema);
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   return shapeFactoryWrapper({
     name: 'line',
@@ -46,6 +47,6 @@ export const line: ShapeFactory<LineSchema> = (options) => {
     efficientHitbox,
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/rect/index.ts
+++ b/packages/shapes/src/shapes/rect/index.ts
@@ -17,7 +17,9 @@ export const rect: ShapeFactory<RectSchema> = (options) => {
   validateBorderRadius(options);
 
   const schema = resolveRectDefaults(options);
-  const text = getShapeTextProps(getCenterPoint(schema), schema.textArea);
+  const drawShape = drawRectWithCtx(schema);
+  const text = getShapeTextProps(getCenterPoint(schema), schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
 
   const shapeHitbox = rectHitbox(schema);
   const efficientHitbox = rectEfficientHitbox(schema);
@@ -26,11 +28,10 @@ export const rect: ShapeFactory<RectSchema> = (options) => {
 
   const getBoundingBox = getRectBoundingBox(schema);
 
-  const drawShape = drawRectWithCtx(schema);
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   return shapeFactoryWrapper({
     name: 'rect',
@@ -44,6 +45,6 @@ export const rect: ShapeFactory<RectSchema> = (options) => {
 
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/scribble/index.ts
+++ b/packages/shapes/src/shapes/scribble/index.ts
@@ -27,17 +27,18 @@ export const scribble: ShapeFactory<ScribbleSchema> = (options) => {
   const getBoundingBox = getScribbleBoundingBox(schema);
 
   const anchorPt = getCenterPoint(getBoundingBox());
-  const text = getShapeTextProps(anchorPt, schema.textArea);
+  const drawShape = drawScribbleWithCtx(schema);
+  const text = getShapeTextProps(anchorPt, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
 
   const shapeHitbox = scribbleHitbox(schema);
   const efficientHitbox = scribbleEfficientHitbox(schema);
   const hitbox = (pt: Coordinate) => text?.textHitbox(pt) || shapeHitbox(pt);
 
-  const drawShape = drawScribbleWithCtx(schema);
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   return shapeFactoryWrapper({
     name: 'scribble',
@@ -51,6 +52,6 @@ export const scribble: ShapeFactory<ScribbleSchema> = (options) => {
 
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/star/index.ts
+++ b/packages/shapes/src/shapes/star/index.ts
@@ -24,13 +24,13 @@ export const star: ShapeFactory<StarSchema> = (options) => {
     console.warn('radius values must be positive');
   }
 
-  const text = getShapeTextProps(schema.at, schema.textArea);
-
   const drawShape = drawStarWithCtx(schema);
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const text = getShapeTextProps(schema.at, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   const shapeHitbox = starHitbox(schema);
   const hitbox = (pt: Coordinate) => text?.textHitbox(pt) || shapeHitbox(pt);
@@ -48,6 +48,6 @@ export const star: ShapeFactory<StarSchema> = (options) => {
     efficientHitbox,
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/triangle/index.ts
+++ b/packages/shapes/src/shapes/triangle/index.ts
@@ -17,17 +17,18 @@ export const triangle: ShapeFactory<TriangleSchema> = (options) => {
 
   const getBoundingBox = getTriangleBoundingBox(schema);
   const anchorPt = getCenterPoint(getBoundingBox());
-  const text = getShapeTextProps(anchorPt, schema.textArea);
+  const drawShape = drawTriangleWithCtx(schema);
+  const text = getShapeTextProps(anchorPt, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
 
   const shapeHitbox = triangleHitbox(schema);
   const efficientHitbox = triangleEfficientHitbox(schema);
   const hitbox = (pt: Coordinate) => text?.textHitbox(pt) || shapeHitbox(pt);
 
-  const drawShape = drawTriangleWithCtx(schema);
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   return shapeFactoryWrapper({
     name: 'triangle',
@@ -40,6 +41,6 @@ export const triangle: ShapeFactory<TriangleSchema> = (options) => {
     efficientHitbox,
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/shapes/uturn/index.ts
+++ b/packages/shapes/src/shapes/uturn/index.ts
@@ -23,7 +23,9 @@ export const uturn: ShapeFactory<UTurnSchema> = (options) => {
 
   const schema = resolveUTurnDefaults(options);
   const anchorPt = getTextAreaAnchorPoint(schema);
-  const text = getShapeTextProps(anchorPt, schema.textArea);
+  const drawShape = drawUTurnWithCtx(schema);
+  const text = getShapeTextProps(anchorPt, schema.textArea, drawShape);
+  const { drawOverride, ...textProps } = text ?? {};
 
   const getBoundingBox = getUTurnBoundingBox(schema);
 
@@ -31,11 +33,10 @@ export const uturn: ShapeFactory<UTurnSchema> = (options) => {
   const shapeHitbox = uturnHitbox(schema);
   const efficientHitbox = uturnEfficientHitbox(schema);
 
-  const drawShape = drawUTurnWithCtx(schema);
-  const draw = (ctx: CanvasRenderingContext2D) => {
+  const draw = drawOverride ?? ((ctx: CanvasRenderingContext2D) => {
     drawShape(ctx);
     text?.drawTextArea(ctx);
-  };
+  });
 
   return shapeFactoryWrapper({
     name: 'uturn',
@@ -49,6 +50,6 @@ export const uturn: ShapeFactory<UTurnSchema> = (options) => {
 
     getBoundingBox,
 
-    ...text,
+    ...textProps,
   });
 };

--- a/packages/shapes/src/text/drawWithNoMatte.ts
+++ b/packages/shapes/src/text/drawWithNoMatte.ts
@@ -47,7 +47,7 @@ const compositeToMain = (ctx: CanvasRenderingContext2D, offCtx: CanvasRenderingC
 };
 
 /**
- * Draws a shape with a transparent text area using offscreen canvas compositing.
+ * Draws a shape with a no-matte text area using offscreen canvas compositing.
  *
  * Instead of painting a solid matte behind the text, the shape is rendered to an
  * offscreen canvas where the text area is punched transparent with destination-out
@@ -56,9 +56,9 @@ const compositeToMain = (ctx: CanvasRenderingContext2D, offCtx: CanvasRenderingC
  * text area. Text is then drawn directly on the main canvas on top.
  *
  * This keeps all compositing complexity isolated to the shapes layer — callers
- * simply pass `color: 'transparent'` on the text area schema.
+ * simply pass `color: 'none'` on the text area schema.
  */
-export const drawWithTransparentTextArea = (
+export const drawWithNoMatte = (
   ctx: CanvasRenderingContext2D,
   drawShape: DrawFn,
   textArea: DeepRequired<TextAreaWithAnchorPoint>,

--- a/packages/shapes/src/text/drawWithTransparentTextArea.ts
+++ b/packages/shapes/src/text/drawWithTransparentTextArea.ts
@@ -1,0 +1,75 @@
+import type { DeepRequired } from 'ts-essentials';
+
+import type { getTextAreaDimension } from './text.ts';
+import type { TextAreaWithAnchorPoint } from './types.ts';
+
+type DrawFn = (ctx: CanvasRenderingContext2D) => void;
+type TextAreaDimensions = ReturnType<typeof getTextAreaDimension>;
+
+/**
+ * Creates an offscreen canvas that mirrors the main canvas's pixel dimensions
+ * and has the same camera transform applied, ready for isolated drawing.
+ */
+const createOffscreenCanvas = (ctx: CanvasRenderingContext2D): CanvasRenderingContext2D => {
+  const offscreen = document.createElement('canvas');
+  offscreen.width = ctx.canvas.width;
+  offscreen.height = ctx.canvas.height;
+
+  const offCtx = offscreen.getContext('2d')!;
+  offCtx.setTransform(ctx.getTransform());
+
+  return offCtx;
+};
+
+/**
+ * Punches a transparent rectangle into the offscreen canvas at the text area's position.
+ * Uses destination-out compositing so only pixels within the rect are erased.
+ */
+const punchTextAreaHole = (
+  offCtx: CanvasRenderingContext2D,
+  textArea: DeepRequired<TextAreaWithAnchorPoint>,
+  dimensions: TextAreaDimensions,
+) => {
+  offCtx.globalCompositeOperation = 'destination-out';
+  offCtx.fillRect(textArea.at.x, textArea.at.y, dimensions.width, dimensions.height);
+  offCtx.globalCompositeOperation = 'source-over';
+};
+
+/**
+ * Composites the offscreen canvas onto the main canvas.
+ * Transform is reset so offscreen pixels map 1:1 to main canvas pixels.
+ */
+const compositeToMain = (ctx: CanvasRenderingContext2D, offCtx: CanvasRenderingContext2D) => {
+  ctx.save();
+  ctx.resetTransform();
+  ctx.drawImage(offCtx.canvas, 0, 0);
+  ctx.restore();
+};
+
+/**
+ * Draws a shape with a transparent text area using offscreen canvas compositing.
+ *
+ * Instead of painting a solid matte behind the text, the shape is rendered to an
+ * offscreen canvas where the text area is punched transparent with destination-out
+ * compositing. The result is then composited onto the main canvas, leaving whatever
+ * was drawn beneath (e.g. background pattern, other shapes) visible through the
+ * text area. Text is then drawn directly on the main canvas on top.
+ *
+ * This keeps all compositing complexity isolated to the shapes layer — callers
+ * simply pass `color: 'transparent'` on the text area schema.
+ */
+export const drawWithTransparentTextArea = (
+  ctx: CanvasRenderingContext2D,
+  drawShape: DrawFn,
+  textArea: DeepRequired<TextAreaWithAnchorPoint>,
+  dimensions: TextAreaDimensions,
+  drawText: DrawFn,
+) => {
+  const offCtx = createOffscreenCanvas(ctx);
+
+  drawShape(offCtx);
+  punchTextAreaHole(offCtx, textArea, dimensions);
+  compositeToMain(ctx, offCtx);
+
+  drawText(ctx);
+};

--- a/packages/shapes/src/text/text.ts
+++ b/packages/shapes/src/text/text.ts
@@ -5,7 +5,7 @@ import type { ShapeTextProps } from '../types/index.ts';
 import type { Coordinate } from '../types/utility.ts';
 import { createTextarea } from './createTextarea.ts';
 import type { TextAreaWithDefaults } from './defaults.ts';
-import { drawWithTransparentTextArea } from './drawWithTransparentTextArea.ts';
+import { drawWithNoMatte } from './drawWithNoMatte.ts';
 import { getTextDimensions } from './getTextDimensions.ts';
 import type {
   StartTextAreaEdit,
@@ -20,7 +20,7 @@ type DrawFn = (ctx: CanvasRenderingContext2D) => void;
 /**
  * Returned by {@link getShapeTextProps}. Extends {@link ShapeTextProps} with an
  * optional `drawOverride` that replaces the shape factory's default draw function
- * when the text area color is `'transparent'`. Shape factories should use this
+ * when the text area color is `'none'`. Shape factories should use this
  * instead of their own draw when it is defined.
  */
 export type ShapeTextPropsResult = ShapeTextProps & {
@@ -62,17 +62,30 @@ export const getShapeTextProps = (
     createTextarea(ctx, onTextAreaBlur, placedTextArea);
   };
 
-  const isTransparent = placedTextArea.color === 'transparent';
+  const isNoMatte = placedTextArea.color === 'none';
 
   const drawOverride =
-    isTransparent && drawShape
+    isNoMatte && drawShape
       ? (ctx: CanvasRenderingContext2D) =>
-          drawWithTransparentTextArea(ctx, drawShape, placedTextArea, dimensions, drawText)
+          drawWithNoMatte(ctx, drawShape, placedTextArea, dimensions, drawText)
       : undefined;
+
+  const drawTextAreaHole = isNoMatte
+    ? (ctx: CanvasRenderingContext2D) => {
+        ctx.fillStyle = 'black';
+        ctx.fillRect(
+          placedTextArea.at.x,
+          placedTextArea.at.y,
+          dimensions.width,
+          dimensions.height,
+        );
+      }
+    : undefined;
 
   return {
     textHitbox: textAreaMatte.hitbox,
     drawTextAreaMatte: textAreaMatte.draw,
+    drawTextAreaHole,
     drawText,
     drawTextArea,
     startTextAreaEdit,

--- a/packages/shapes/src/text/text.ts
+++ b/packages/shapes/src/text/text.ts
@@ -5,6 +5,7 @@ import type { ShapeTextProps } from '../types/index.ts';
 import type { Coordinate } from '../types/utility.ts';
 import { createTextarea } from './createTextarea.ts';
 import type { TextAreaWithDefaults } from './defaults.ts';
+import { drawWithTransparentTextArea } from './drawWithTransparentTextArea.ts';
 import { getTextDimensions } from './getTextDimensions.ts';
 import type {
   StartTextAreaEdit,
@@ -14,15 +15,23 @@ import type {
 
 export const HORIZONTAL_TEXT_PADDING = 20;
 
+type DrawFn = (ctx: CanvasRenderingContext2D) => void;
+
 /**
- * if a text area is provided, will return ShapeTextProps, otherwise undefined
+ * Returned by {@link getShapeTextProps}. Extends {@link ShapeTextProps} with an
+ * optional `drawOverride` that replaces the shape factory's default draw function
+ * when the text area color is `'transparent'`. Shape factories should use this
+ * instead of their own draw when it is defined.
  */
-type ShapeTextPropsGetter = (
+export type ShapeTextPropsResult = ShapeTextProps & {
+  drawOverride?: DrawFn;
+};
+
+export const getShapeTextProps = (
   at?: Coordinate,
   textArea?: TextAreaWithDefaults,
-) => ShapeTextProps | undefined;
-
-export const getShapeTextProps: ShapeTextPropsGetter = (at, textArea) => {
+  drawShape?: DrawFn,
+): ShapeTextPropsResult | undefined => {
   if (!at || !textArea) return;
 
   const dimensions = getTextAreaDimension(textArea.textBlock);
@@ -53,12 +62,21 @@ export const getShapeTextProps: ShapeTextPropsGetter = (at, textArea) => {
     createTextarea(ctx, onTextAreaBlur, placedTextArea);
   };
 
+  const isTransparent = placedTextArea.color === 'transparent';
+
+  const drawOverride =
+    isTransparent && drawShape
+      ? (ctx: CanvasRenderingContext2D) =>
+          drawWithTransparentTextArea(ctx, drawShape, placedTextArea, dimensions, drawText)
+      : undefined;
+
   return {
     textHitbox: textAreaMatte.hitbox,
     drawTextAreaMatte: textAreaMatte.draw,
     drawText,
     drawTextArea,
     startTextAreaEdit,
+    drawOverride,
   };
 };
 

--- a/packages/shapes/src/types/index.ts
+++ b/packages/shapes/src/types/index.ts
@@ -45,6 +45,12 @@ export type ShapeTextProps = {
    */
   drawTextAreaMatte: (ctx: CanvasRenderingContext2D) => void;
   /**
+   * fills the text area bounds with an opaque rect, for use with destination-out
+   * compositing to punch a transparent hole. unlike `drawTextAreaMatte`, this
+   * always draws opaquely regardless of the text area's color setting.
+   */
+  drawTextAreaHole?: (ctx: CanvasRenderingContext2D) => void;
+  /**
    * only draws the text content of the text area
    */
   drawText: (ctx: CanvasRenderingContext2D) => void;
@@ -145,6 +151,7 @@ export type EverySchemaPropName = keyof UnionToIntersection<EverySchemaProp>;
  */
 export const shapeProps: Set<keyof Shape> = new Set([
   'drawTextAreaMatte',
+  'drawTextAreaHole',
   'drawText',
   'drawTextArea',
   'textHitbox',


### PR DESCRIPTION
Replaces index-based draw ordering with a priority-group compositing model. Shapes now declare a static priority tier (edges = 1, nodes = 2) and drawGroup handles layering within each tier using a shared offscreen canvas.

The core problem this solves: when edges cross each other's text area bounds, the matte from one edge would clip the line of another. By drawing all shapes in a group to a single offscreen canvas and punching text area holes with destination-out compositing before flattening to the main canvas, crossing lines are preserved correctly.

## Changes:

New drawGroup in @magic/shapes — offscreen compositing pipeline for a set of shapes
color: 'none' on a text area opts the shape into no-matte rendering via drawWithNoMatte
drawTextAreaHole added to ShapeTextProps for use by drawGroup's punch pass
getShapeTextProps now accepts the shape's own drawShape fn and returns an optional drawOverride for single-shape no-matte cases
Priority tiers replace the old i * 10 / i * 10 + 1000 index arithmetic in the canvas plugin