### PR TITLE
feat: add optional plugin dependency support

### DIFF
--- a/packages/graph-plugins/src/plugins/anchors/index.ts
+++ b/packages/graph-plugins/src/plugins/anchors/index.ts
@@ -7,7 +7,7 @@ import type { WithId } from '@magic/shapes/types/index';
 import { nullThrows } from '@magic/utils/assert';
 import { MOUSE_BUTTONS } from '@magic/utils/mouse';
 
-import { DeepReadonly, readonly, ref } from 'vue';
+import { readonly, ref } from 'vue';
 
 import type { AnchorsPlugin, NodeAnchor } from '../../plugins/anchors/types.ts';
 import { CanvasEventMap, CanvasGraphMouseEvent } from '../canvas/events.ts';
@@ -95,8 +95,7 @@ export const anchors: AnchorsPlugin = (
       const isAnchorHovered = id === hoveredNodeAnchorId.value;
       const isAnchorDragged = id === draggedAnchor?.id;
 
-      // TODO https://github.com/Yonava/magic-graphs/issues/707
-      const isNodeFocused = controls.focus.isFocused(node.id);
+      const isNodeFocused = controls.focus?.isFocused(node.id) ?? false;
       const isFocused = isNodeFocused || isAnchorHovered || isAnchorDragged;
 
       const nodeAnchorSchema: WithId<CircleSchema> = {
@@ -146,8 +145,7 @@ export const anchors: AnchorsPlugin = (
     if (!node) return (nodeAnchors.value = []);
     const { _resolveToken: resolveToken } = controls.canvas.theme;
 
-    // TODO https://github.com/Yonava/magic-graphs/issues/707
-    const isNodeFocused = controls.focus.isFocused(node.id);
+    const isNodeFocused = controls.focus?.isFocused(node.id) ?? false;
 
     const anchorBaseRadius = resolveToken('nodeAnchor.default.radius', node);
     const anchorFocusRadius = resolveToken('nodeAnchor.focus.radius', node);
@@ -216,8 +214,7 @@ export const anchors: AnchorsPlugin = (
     const end = { x, y };
     const { _resolveToken: resolveToken } = controls.canvas.theme;
 
-    // TODO https://github.com/Yonava/magic-graphs/issues/707
-    const isFocused = controls.focus.isFocused(currentParentNode.id);
+    const isFocused = controls.focus?.isFocused(currentParentNode.id) ?? false;
 
     const baseColor = resolveToken(
       'nodeAnchor.default.linkPreview.color',

--- a/packages/graph-plugins/src/plugins/anchors/types.ts
+++ b/packages/graph-plugins/src/plugins/anchors/types.ts
@@ -46,5 +46,6 @@ export type AnchorsPlugin = GraphPlugin<{
   controls: { anchors: WithLifecycle<AnchorsControls> };
   events: AnchorsEventMap;
   actions: {};
-  dependsOn: [CanvasPlugin, FocusPlugin];
+  dependsOn: [CanvasPlugin];
+  optionalDependsOn: [FocusPlugin];
 }>;

--- a/packages/graph/src/plugins/types.ts
+++ b/packages/graph/src/plugins/types.ts
@@ -57,6 +57,7 @@ type LoosePluginData = {
   getters: Partial<BaseGetters>;
   actions: PartialBaseActions;
   dependsOn: LooseGraphPlugin[];
+  optionalDependsOn: LooseGraphPlugin[];
 };
 
 type DefaultPluginData = {
@@ -65,6 +66,7 @@ type DefaultPluginData = {
   getters: {};
   actions: {};
   dependsOn: [];
+  optionalDependsOn: [];
 };
 
 type ResolvePluginData<PartialPluginData> = {
@@ -90,8 +92,18 @@ export type GraphPlugin<PluginData extends Partial<LoosePluginData>> =
  * downstream plugins and consumers only ever see what's returned here.
  */
 type ResolvedGraphPlugin<PluginData extends LoosePluginData> = (
-  controls: CoreControls & ExtractControls<PluginData['dependsOn']>,
-  events: EventHub<CoreEventMap & ExtractEventMap<PluginData['dependsOn']>>,
+  controls: CoreControls &
+    ExtractControls<PluginData['dependsOn']> &
+    (PluginData['optionalDependsOn'] extends never[]
+      ? {}
+      : Partial<ExtractControls<PluginData['optionalDependsOn']>>),
+  events: EventHub<
+    CoreEventMap &
+      ExtractEventMap<PluginData['dependsOn']> &
+      (PluginData['optionalDependsOn'] extends never[]
+        ? {}
+        : ExtractEventMap<PluginData['optionalDependsOn']>)
+  >,
   actions: GraphActions<CoreActions>,
   getters: GraphGetters<CoreGetters>,
 ) => {
@@ -99,6 +111,9 @@ type ResolvedGraphPlugin<PluginData extends LoosePluginData> = (
   events: EventHub<
     CoreEventMap &
       ExtractEventMap<PluginData['dependsOn']> &
+      (PluginData['optionalDependsOn'] extends never[]
+        ? {}
+        : ExtractEventMap<PluginData['optionalDependsOn']>) &
       PluginData['events']
   >;
   getters: GraphGetters<MergeGetters<[PluginData['getters'], CoreGetters]>>;


### PR DESCRIPTION
## Summary

Introduces `optionalDependsOn` to the `GraphPlugin` type, allowing plugins to declare soft dependencies that may or may not be present at runtime.

- Adds `optionalDependsOn` field to `LoosePluginData` and `DefaultPluginData`, with controls typed as `Partial` and events merged into the hub without ordering enforcement
- Converts `anchors`' hard dependency on `focus` to an optional one, replacing three TODO-guarded `controls.focus.*` calls with `controls.focus?.` null-safe access

This unblocks plugin compositions where `anchors` is used without `focus`, removing the need for the workarounds previously tracked via TODO comments.