### PR TITLE
feat: promote plugin name to first-class field

### DIFF
--- a/packages/create-graph/src/index.ts
+++ b/packages/create-graph/src/index.ts
@@ -80,32 +80,30 @@ export const createGraph = <
       actions: evolvingActions,
       getters: evolvingGetters,
     });
-    evolvingControls = { ...evolvingControls, ...pluginResult.controls };
+    evolvingControls = {
+      ...evolvingControls,
+      [pluginResult.name]: pluginResult.controls,
+    };
     evolvingEvents = pluginResult.events;
     evolvingActions = { ...evolvingActions, ...pluginResult.actions };
     evolvingGetters = { ...evolvingGetters, ...pluginResult.getters };
 
-    // TODO make the contract to define plugin name scope in the controls more explicit!
-    // Something like the plugin itself exposes a name field in pluginResult like pluginResult.name = 'focus'
-    const pluginName = nullThrows(
-      Object.keys(pluginResult.controls).at(0),
-      'Could not resolve name of plugin',
-    );
     const pluginThemeField: PluginThemeField<any>['theme'] | undefined = (
       pluginResult.controls as any
-    )[pluginName]?.theme;
+    )?.theme;
 
     if (pluginThemeField) {
       const { set } = pluginThemeField.createLayer(
         'create-graph/theme-presets',
       );
       const tokens = Object.keys(
-        (themePresets as any)[activePresetName][pluginName],
+        (themePresets as any)[activePresetName][pluginResult.name],
       );
       for (const token of tokens) {
         set(
           token,
-          () => (themePresets as any)[activePresetName][pluginName][token],
+          () =>
+            (themePresets as any)[activePresetName][pluginResult.name][token],
         );
       }
 

--- a/packages/create-graph/src/index.ts
+++ b/packages/create-graph/src/index.ts
@@ -16,7 +16,11 @@ import {
   CanvasElement,
 } from '@magic/graph-plugins/canvas/aggregator/types';
 import { CANVAS_ELEMENT_CURSOR_FIELD_KEY } from '@magic/graph-plugins/canvas/setupCanvasCursor';
-import { CanvasControls } from '@magic/graph-plugins/canvas/types';
+import {
+  CanvasControls,
+  CanvasPlugin,
+} from '@magic/graph-plugins/canvas/types';
+import { FocusPlugin } from '@magic/graph-plugins/focus/types';
 import { GraphActions } from '@magic/graph-primitives/actions/types';
 import { EventHub } from '@magic/graph-primitives/events/createEventHub';
 import { GraphGetters } from '@magic/graph-primitives/getters/types';
@@ -117,7 +121,7 @@ export const createGraph = <
   const events = evolvingEvents as EventHub<ExtractEventMap<NoInfer<TPlugins>>>;
 
   const controls = evolvingControls as Prettify<
-    CoreControls & ExtractControls<NoInfer<TPlugins>>
+    ExtractControls<NoInfer<TPlugins>>
   >;
 
   const actions = evolvingActions as GraphActions<

--- a/packages/graph-plugins-shared/src/computed-tokens/index.ts
+++ b/packages/graph-plugins-shared/src/computed-tokens/index.ts
@@ -1,8 +1,14 @@
 /** Resolves computed token values for nodes and edges by running detectors in precedence order. */
-export { CompoundTokenResolver, createComputedTokenResolver } from './internals/createComputedTokenResolver.ts';
+export {
+  type CompoundTokenResolver,
+  createComputedTokenResolver,
+} from './internals/createComputedTokenResolver.ts';
 
 /** The map of detector functions keyed by computed token state, used to resolve node and edge style tokens. */
-export type { ComputedTokenDetectorMap, ComputedTokenState } from './internals/types.ts';
+export type {
+  ComputedTokenDetectorMap,
+  ComputedTokenState,
+} from './internals/types.ts';
 
 /** The computed style tokens available for nodes. */
 export type { NodeComputedTokens } from './internals/types.ts';

--- a/packages/graph-plugins-shared/src/plugins/index.ts
+++ b/packages/graph-plugins-shared/src/plugins/index.ts
@@ -3,13 +3,13 @@ import { LooseGraphPlugin } from './internals/loose.ts';
 // --- for plugin authors ---
 
 /** The type for a graph plugin. Use this to type your plugin function. */
-export { GraphPlugin } from './internals/plugin.ts';
+export type { GraphPlugin } from './internals/plugin.ts';
 
 /** Wraps a plugin's controls with lifecycle methods (enable/disable). */
-export { WithLifecycle } from './internals/lifecycle.ts';
+export type { WithLifecycle } from './internals/lifecycle.ts';
 
 /** Wraps a plugin's controls with a theme controller. */
-export { WithTheme, PluginThemeField } from './internals/themes.ts';
+export type { WithTheme, PluginThemeField } from './internals/themes.ts';
 
 /** Extracts the options type from a plugin function's first parameter. */
 export type PluginOptions<Plugin extends LooseGraphPlugin> =
@@ -21,19 +21,19 @@ export type PluginOptions<Plugin extends LooseGraphPlugin> =
  * The loose, unresolved plugin type used for plugin list inference.
  * Plugin authors should use {@link GraphPlugin} instead.
  */
-export { LooseGraphPlugin };
+export type { LooseGraphPlugin };
 
 /** Extracts the merged theme map from a list of plugins. To build the theming interface. */
-export { PluginThemes } from './internals/themes.ts';
+export type { PluginThemes } from './internals/themes.ts';
 
 /** Extracts the merged controls type from a list of plugins. To assemble the graph controls. */
-export { ExtractControls } from './internals/extractors.ts';
+export type { ExtractControls } from './internals/extractors.ts';
 
 /** Extracts the merged event map from a list of plugins. To wire the event hub. */
-export { ExtractEventMap } from './internals/extractors.ts';
+export type { ExtractEventMap } from './internals/extractors.ts';
 
 /** Extracts the merged getters type from a list of plugins. To build the getters interface. */
-export { ExtractGetters } from './internals/extractors.ts';
+export type { ExtractGetters } from './internals/extractors.ts';
 
 /** Extracts the merged actions type from a list of plugins. To build the actions interface. */
-export { ExtractActions } from './internals/extractors.ts';
+export type { ExtractActions } from './internals/extractors.ts';

--- a/packages/graph-plugins-shared/src/plugins/internals/defaults.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/defaults.ts
@@ -1,6 +1,8 @@
+import { PartiallyPartial } from '@magic/utils/types';
+
 import { LoosePluginSchema } from './loose.ts';
 
-type DefaultPluginSchema = {
+export type DefaultPluginSchema = {
   controls: {};
   events: {};
   getters: {};
@@ -9,8 +11,13 @@ type DefaultPluginSchema = {
   optionalDependsOn: [];
 };
 
-export type ResolvePluginData<PartialPluginData> = {
-  [K in keyof LoosePluginSchema]: K extends keyof PartialPluginData
-    ? NonNullable<PartialPluginData[K]>
+export type TestSchema = PartiallyPartial<
+  LoosePluginSchema,
+  keyof DefaultPluginSchema
+>;
+
+export type ResolvePluginSchema<Schema extends TestSchema> = {
+  [K in keyof DefaultPluginSchema]: K extends keyof Schema
+    ? NonNullable<Schema[K]>
     : DefaultPluginSchema[K];
 };

--- a/packages/graph-plugins-shared/src/plugins/internals/defaults.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/defaults.ts
@@ -3,7 +3,7 @@ import { Prettify } from 'ts-essentials';
 
 import { LoosePluginSchema } from './loose.ts';
 
-export type DefaultPluginSchema = {
+export type PluginSchemaDefaults = {
   controls: {};
   events: {};
   getters: {};
@@ -12,17 +12,15 @@ export type DefaultPluginSchema = {
   optionalDependsOn: [];
 };
 
-export type TestSchema = PartiallyPartial<
+export type PluginSchemaInput = PartiallyPartial<
   LoosePluginSchema,
-  keyof DefaultPluginSchema
+  keyof PluginSchemaDefaults
 >;
 
-export type ResolvePluginSchema<Schema extends TestSchema> = Prettify<
+export type ResolvePluginSchema<Schema extends PluginSchemaInput> = Prettify<
   {
-    [K in keyof DefaultPluginSchema]: K extends keyof Schema
+    [K in keyof PluginSchemaDefaults]: K extends keyof Schema
       ? NonNullable<Schema[K]>
-      : DefaultPluginSchema[K];
-  } & Omit<Schema, keyof DefaultPluginSchema>
+      : PluginSchemaDefaults[K];
+  } & Omit<Schema, keyof PluginSchemaDefaults>
 >;
-
-type t = ResolvePluginSchema<{ name: string }>;

--- a/packages/graph-plugins-shared/src/plugins/internals/defaults.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/defaults.ts
@@ -1,4 +1,5 @@
 import { PartiallyPartial } from '@magic/utils/types';
+import { Prettify } from 'ts-essentials';
 
 import { LoosePluginSchema } from './loose.ts';
 
@@ -16,8 +17,12 @@ export type TestSchema = PartiallyPartial<
   keyof DefaultPluginSchema
 >;
 
-export type ResolvePluginSchema<Schema extends TestSchema> = {
-  [K in keyof DefaultPluginSchema]: K extends keyof Schema
-    ? NonNullable<Schema[K]>
-    : DefaultPluginSchema[K];
-};
+export type ResolvePluginSchema<Schema extends TestSchema> = Prettify<
+  {
+    [K in keyof DefaultPluginSchema]: K extends keyof Schema
+      ? NonNullable<Schema[K]>
+      : DefaultPluginSchema[K];
+  } & Omit<Schema, keyof DefaultPluginSchema>
+>;
+
+type t = ResolvePluginSchema<{ name: string }>;

--- a/packages/graph-plugins-shared/src/plugins/internals/extractors.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/extractors.ts
@@ -1,6 +1,7 @@
 import { CoreActions } from '@magic/graph-core/actions/types';
 import { CoreEventMap } from '@magic/graph-core/events';
 import { CoreGetters } from '@magic/graph-core/getters';
+import { CoreControls } from '@magic/graph-core/types';
 import { GraphActions } from '@magic/graph-primitives/actions/types';
 import { EventHub } from '@magic/graph-primitives/events/createEventHub';
 import { BaseGetters } from '@magic/graph-primitives/getters/types';
@@ -10,12 +11,20 @@ import { LooseGraphPlugin } from './loose.ts';
 
 type RemoveArray<T> = T extends (infer F)[] ? F : T;
 
-type ExtractData<TPlugins extends LooseGraphPlugin[]> = UnionToIntersection<
-  ReturnType<RemoveArray<NoInfer<TPlugins>>>
->;
+type ResolveControls<Plugin extends LooseGraphPlugin> = Plugin extends Plugin
+  ? ReturnType<Plugin> extends {
+      name: infer Name extends string;
+      controls: infer Controls;
+    }
+    ? Record<Name, Controls>
+    : never
+  : never;
 
 export type ExtractControls<TPlugins extends LooseGraphPlugin[]> =
-  ExtractData<TPlugins> extends { controls: infer Controls } ? Controls : never;
+  CoreControls &
+    (TPlugins extends never[]
+      ? {}
+      : UnionToIntersection<ResolveControls<RemoveArray<NoInfer<TPlugins>>>>);
 
 export type ExtractActions<TPlugins extends LooseGraphPlugin[]> =
   TPlugins extends never[]

--- a/packages/graph-plugins-shared/src/plugins/internals/loose.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/loose.ts
@@ -13,6 +13,7 @@ import {
 } from '@magic/graph-primitives/getters/types';
 
 type LooseGraphPluginOptions = {
+  name: string;
   controls: any;
   events: EventHub<CoreEventMap>;
   actions: GraphActions<CoreActions>;
@@ -20,6 +21,7 @@ type LooseGraphPluginOptions = {
 };
 
 export type LoosePluginSchema = {
+  name: string;
   controls: object;
   events: GenericEventMap;
   getters: Partial<BaseGetters>;
@@ -29,6 +31,7 @@ export type LoosePluginSchema = {
 };
 
 export type LooseGraphPlugin = (options: LooseGraphPluginOptions) => {
+  name: string;
   controls: LoosePluginSchema['controls'];
   // [1]
   events: EventHub<CoreEventMap & LoosePluginSchema['events']>;

--- a/packages/graph-plugins-shared/src/plugins/internals/loose.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/loose.ts
@@ -12,14 +12,6 @@ import {
   GraphGetters,
 } from '@magic/graph-primitives/getters/types';
 
-type LooseGraphPluginOptions = {
-  name: string;
-  controls: any;
-  events: EventHub<CoreEventMap>;
-  actions: GraphActions<CoreActions>;
-  getters: GraphGetters<CoreGetters>;
-};
-
 export type LoosePluginSchema = {
   name: string;
   controls: object;
@@ -30,8 +22,15 @@ export type LoosePluginSchema = {
   optionalDependsOn: LooseGraphPlugin[];
 };
 
-export type LooseGraphPlugin = (options: LooseGraphPluginOptions) => {
-  name: string;
+type LoosePluginInput = {
+  controls: any;
+  events: EventHub<CoreEventMap>;
+  actions: GraphActions<CoreActions>;
+  getters: GraphGetters<CoreGetters>;
+};
+
+type LoosePluginOutput = {
+  name: LooseGraphPlugin['name'];
   controls: LoosePluginSchema['controls'];
   // [1]
   events: EventHub<CoreEventMap & LoosePluginSchema['events']>;
@@ -39,6 +38,8 @@ export type LooseGraphPlugin = (options: LooseGraphPluginOptions) => {
   getters: GraphGetters<any>;
   onAfterInit?: () => void;
 };
+
+export type LooseGraphPlugin = (options: LoosePluginInput) => LoosePluginOutput;
 
 // [1] `CoreEventMap` is intersected into the return type (not just the events
 // param) to keep the "merge yourself" contract honest at the type level: every

--- a/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
@@ -12,13 +12,12 @@ import {
   MergeGetters,
 } from '@magic/graph-primitives/getters/types';
 
-import { ResolvePluginSchema, TestSchema } from './defaults.ts';
+import { PluginSchemaInput, ResolvePluginSchema } from './defaults.ts';
 import { ExtractControls, ExtractEventMap } from './extractors.ts';
 import { LoosePluginSchema } from './loose.ts';
 
-export type GraphPlugin<PluginSchema extends TestSchema> = ResolvedGraphPlugin<
-  ResolvePluginSchema<PluginSchema>
->;
+export type GraphPlugin<PluginSchema extends PluginSchemaInput> =
+  ResolvedGraphPlugin<ResolvePluginSchema<PluginSchema>>;
 
 type PluginInput<PluginSchema extends LoosePluginSchema> = {
   controls: CoreControls &

--- a/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
@@ -37,6 +37,7 @@ type PluginInput<PluginSchema extends LoosePluginSchema> = {
 };
 
 type PluginOutput<PluginSchema extends LoosePluginSchema> = {
+  name: string;
   controls: PluginSchema['controls'];
   // [1]
   events: EventHub<

--- a/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
@@ -11,13 +11,8 @@ import {
   GraphGetters,
   MergeGetters,
 } from '@magic/graph-primitives/getters/types';
-import { PartiallyPartial } from '@magic/utils/types';
 
-import {
-  DefaultPluginSchema,
-  ResolvePluginSchema,
-  TestSchema,
-} from './defaults.ts';
+import { ResolvePluginSchema, TestSchema } from './defaults.ts';
 import { ExtractControls, ExtractEventMap } from './extractors.ts';
 import { LoosePluginSchema } from './loose.ts';
 
@@ -59,7 +54,7 @@ type PluginOutput<PluginSchema extends LoosePluginSchema> = {
   onAfterInit?: () => void;
 };
 
-type ResolvedGraphPlugin<PluginSchema extends TestSchema> = (
+type ResolvedGraphPlugin<PluginSchema extends LoosePluginSchema> = (
   options: PluginInput<PluginSchema>,
 ) => PluginOutput<PluginSchema>;
 

--- a/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
@@ -38,7 +38,7 @@ type PluginInput<PluginSchema extends LoosePluginSchema> = {
 };
 
 type PluginOutput<PluginSchema extends LoosePluginSchema> = {
-  name: string;
+  name: PluginSchema['name'];
   controls: PluginSchema['controls'];
   // [1]
   events: EventHub<

--- a/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/plugin.ts
@@ -11,13 +11,19 @@ import {
   GraphGetters,
   MergeGetters,
 } from '@magic/graph-primitives/getters/types';
+import { PartiallyPartial } from '@magic/utils/types';
 
-import { ResolvePluginData } from './defaults.ts';
+import {
+  DefaultPluginSchema,
+  ResolvePluginSchema,
+  TestSchema,
+} from './defaults.ts';
 import { ExtractControls, ExtractEventMap } from './extractors.ts';
 import { LoosePluginSchema } from './loose.ts';
 
-export type GraphPlugin<PluginSchema extends Partial<LoosePluginSchema>> =
-  ResolvedGraphPlugin<ResolvePluginData<PluginSchema>>;
+export type GraphPlugin<PluginSchema extends TestSchema> = ResolvedGraphPlugin<
+  ResolvePluginSchema<PluginSchema>
+>;
 
 type PluginInput<PluginSchema extends LoosePluginSchema> = {
   controls: CoreControls &
@@ -53,7 +59,7 @@ type PluginOutput<PluginSchema extends LoosePluginSchema> = {
   onAfterInit?: () => void;
 };
 
-type ResolvedGraphPlugin<PluginSchema extends LoosePluginSchema> = (
+type ResolvedGraphPlugin<PluginSchema extends TestSchema> = (
   options: PluginInput<PluginSchema>,
 ) => PluginOutput<PluginSchema>;
 

--- a/packages/graph-plugins-shared/src/plugins/internals/themes.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/themes.ts
@@ -1,8 +1,8 @@
 import { UnionToIntersection } from 'ts-essentials';
 
+import { ComputedTokenDetectorMap } from '../../computed-tokens/index.ts';
 import { ThemeController } from '../../theme/internals/createThemeController.ts';
 import { LooseGraphPlugin } from './loose.ts';
-import { ComputedTokenDetectorMap } from '../../computed-tokens/index.ts';
 
 type Detectors = {
   /**
@@ -21,16 +21,14 @@ export type PluginThemeField<Themes> = {
 
 export type WithTheme<Controls, Themes> = Controls & PluginThemeField<Themes>;
 
-type ThemeForPlugin<Plugin extends LooseGraphPlugin> = Plugin extends Plugin
-  ? ReturnType<Plugin> extends {
-      controls: Record<
-        infer PluginName extends string,
-        { theme: ThemeController<infer Themes> }
-      >;
-    }
-    ? Record<PluginName, Themes>
-    : never
-  : never;
+export type ThemeForPlugin<Plugin extends LooseGraphPlugin> =
+  Plugin extends Plugin
+    ? ReturnType<Plugin>['controls'] extends {
+        theme: ThemeController<infer Themes>;
+      }
+      ? Record<ReturnType<Plugin>['name'], Themes>
+      : never
+    : never;
 
 export type PluginThemes<Plugins extends LooseGraphPlugin[]> =
   UnionToIntersection<ThemeForPlugin<Plugins[number]>>;

--- a/packages/graph-plugins-shared/src/plugins/internals/themes.ts
+++ b/packages/graph-plugins-shared/src/plugins/internals/themes.ts
@@ -21,14 +21,13 @@ export type PluginThemeField<Themes> = {
 
 export type WithTheme<Controls, Themes> = Controls & PluginThemeField<Themes>;
 
-export type ThemeForPlugin<Plugin extends LooseGraphPlugin> =
-  Plugin extends Plugin
-    ? ReturnType<Plugin>['controls'] extends {
-        theme: ThemeController<infer Themes>;
-      }
-      ? Record<ReturnType<Plugin>['name'], Themes>
-      : never
-    : never;
+type ThemeForPlugin<Plugin extends LooseGraphPlugin> = Plugin extends Plugin
+  ? ReturnType<Plugin>['controls'] extends {
+      theme: ThemeController<infer Themes>;
+    }
+    ? Record<ReturnType<Plugin>['name'], Themes>
+    : never
+  : never;
 
 export type PluginThemes<Plugins extends LooseGraphPlugin[]> =
   UnionToIntersection<ThemeForPlugin<Plugins[number]>>;

--- a/packages/graph-plugins-shared/src/theme/index.ts
+++ b/packages/graph-plugins-shared/src/theme/index.ts
@@ -1,14 +1,24 @@
 /** Controls the active theme for a plugin, exposing override layer management and token resolution. */
-export { ThemeController, createThemeController } from './internals/createThemeController.ts';
+export {
+  type ThemeController,
+  createThemeController,
+} from './internals/createThemeController.ts';
 
 /** Resolves a single theme token against the active override layers and preset. */
-export { TokenResolver, createTokenResolver } from './internals/createTokenResolver.ts';
+export {
+  type TokenResolver,
+  createTokenResolver,
+} from './internals/createTokenResolver.ts';
 
 /** A layered override slot for a single theme token, scoped to a plugin instance. */
-export { ThemeLayer, createLayer } from './internals/createLayer.ts';
+export { type ThemeLayer, createLayer } from './internals/createLayer.ts';
 
 /** A theme token value — either a direct value or a getter that can defer to the next layer. */
-export type { ThemeValue, ThemeOverrides, ThemeOverride } from './internals/types.ts';
+export type {
+  ThemeValue,
+  ThemeOverrides,
+  ThemeOverride,
+} from './internals/types.ts';
 
 /** All cursor values supported by the browser. */
 export { CURSOR, CURSOR_FALLBACK, isValidCursor } from './internals/cursor.ts';

--- a/packages/graph-plugins/src/adjacency-lists/index.ts
+++ b/packages/graph-plugins/src/adjacency-lists/index.ts
@@ -107,8 +107,6 @@ export const adjacencyLists: AdjacencyListsPlugin = ({
     actions,
     getters,
     events,
-    controls: {
-      adjacencyLists: { standard, weighted, directed, undirected },
-    },
+    controls: { standard, weighted, directed, undirected },
   };
 };

--- a/packages/graph-plugins/src/adjacency-lists/index.ts
+++ b/packages/graph-plugins/src/adjacency-lists/index.ts
@@ -103,6 +103,7 @@ export const adjacencyLists: AdjacencyListsPlugin = ({
   events.subscribe('onStructureChange', update);
 
   return {
+    name: 'adjacencyLists',
     actions,
     getters,
     events,

--- a/packages/graph-plugins/src/adjacency-lists/types.ts
+++ b/packages/graph-plugins/src/adjacency-lists/types.ts
@@ -1,13 +1,12 @@
 import { CoreEventMap } from '@magic/graph-core/events';
 import { CoreGetters } from '@magic/graph-core/getters';
 import { CoreControls } from '@magic/graph-core/types';
+import { GraphPlugin } from '@magic/graph-plugins-shared/plugins';
 import { EventHub } from '@magic/graph-primitives/events/createEventHub';
 import { GraphGetters } from '@magic/graph-primitives/getters/types';
 import { CoreNode } from '@magic/graph-primitives/types';
 
 import { Ref } from 'vue';
-
-import { GraphPlugin } from '@magic/graph-plugins-shared/plugins';
 
 /**
  * a mapping of nodes to their neighbors where neighbors are the full node objects
@@ -50,5 +49,5 @@ export type AdjacencyListsControls = {
 };
 
 export type AdjacencyListsPlugin = GraphPlugin<{
-  controls: { adjacencyLists: AdjacencyListsControls };
+  controls: AdjacencyListsControls;
 }>;

--- a/packages/graph-plugins/src/adjacency-lists/types.ts
+++ b/packages/graph-plugins/src/adjacency-lists/types.ts
@@ -49,6 +49,6 @@ export type AdjacencyListsControls = {
 };
 
 export type AdjacencyListsPlugin = GraphPlugin<{
-  name: 'adjacencyList';
+  name: 'adjacencyLists';
   controls: AdjacencyListsControls;
 }>;

--- a/packages/graph-plugins/src/adjacency-lists/types.ts
+++ b/packages/graph-plugins/src/adjacency-lists/types.ts
@@ -49,5 +49,6 @@ export type AdjacencyListsControls = {
 };
 
 export type AdjacencyListsPlugin = GraphPlugin<{
+  name: 'adjacencyList';
   controls: AdjacencyListsControls;
 }>;

--- a/packages/graph-plugins/src/anchors/index.ts
+++ b/packages/graph-plugins/src/anchors/index.ts
@@ -1,8 +1,8 @@
+import { CoreEventMap } from '@magic/graph-core/events';
+import { createThemeController } from '@magic/graph-plugins-shared/theme';
 import { createEventHub } from '@magic/graph-primitives/events/createEventHub';
 import { mergeEventHubs } from '@magic/graph-primitives/events/mergeEventHubs';
 import { CoreNode } from '@magic/graph-primitives/types';
-import { createThemeController } from '@magic/graph-plugins-shared/theme';
-import { CoreEventMap } from '@magic/graph-core/events';
 import type { CircleSchema } from '@magic/shapes/shapes/circle/types';
 import type { WithId } from '@magic/shapes/types/index';
 import { MOUSE_BUTTONS } from '@magic/utils/mouse';
@@ -436,16 +436,14 @@ export const anchors: AnchorsPlugin = ({
     actions,
     getters,
     controls: {
-      anchors: {
-        lifecycle: {
-          enable,
-          disable,
-        },
-        theme,
-        parentNode: readonly(parentNode),
-        setParentNode,
-        clearAnchorState,
+      lifecycle: {
+        enable,
+        disable,
       },
+      theme,
+      parentNode: readonly(parentNode),
+      setParentNode,
+      clearAnchorState,
     },
   };
 };

--- a/packages/graph-plugins/src/anchors/index.ts
+++ b/packages/graph-plugins/src/anchors/index.ts
@@ -431,6 +431,7 @@ export const anchors: AnchorsPlugin = ({
   enable();
 
   return {
+    name: 'anchors',
     events,
     actions,
     getters,

--- a/packages/graph-plugins/src/anchors/types.ts
+++ b/packages/graph-plugins/src/anchors/types.ts
@@ -50,6 +50,7 @@ type BaseAnchorsControls = {
 export type AnchorsControls = WithTheme<BaseAnchorsControls, AnchorsThemes>;
 
 export type AnchorsPlugin = GraphPlugin<{
+  name: 'anchors';
   controls: WithLifecycle<AnchorsControls>;
   events: AnchorsEventMap;
   dependsOn: [CanvasPlugin];

--- a/packages/graph-plugins/src/anchors/types.ts
+++ b/packages/graph-plugins/src/anchors/types.ts
@@ -1,3 +1,8 @@
+import {
+  GraphPlugin,
+  WithLifecycle,
+  WithTheme,
+} from '@magic/graph-plugins-shared/plugins';
 import { CoreNode } from '@magic/graph-primitives/types';
 
 import { Ref } from 'vue';
@@ -6,7 +11,6 @@ import { CanvasPlugin } from '../canvas/types.ts';
 import { FocusPlugin } from '../focus/types.ts';
 import { AnchorsEventMap } from './events.ts';
 import { AnchorsThemes } from './themes.ts';
-import { GraphPlugin, WithLifecycle, WithTheme } from '@magic/graph-plugins-shared/plugins';
 
 /**
  * an anchor instance that is attached to a node
@@ -46,7 +50,7 @@ type BaseAnchorsControls = {
 export type AnchorsControls = WithTheme<BaseAnchorsControls, AnchorsThemes>;
 
 export type AnchorsPlugin = GraphPlugin<{
-  controls: { anchors: WithLifecycle<AnchorsControls> };
+  controls: WithLifecycle<AnchorsControls>;
   events: AnchorsEventMap;
   dependsOn: [CanvasPlugin];
   optionalDependsOn: [FocusPlugin];

--- a/packages/graph-plugins/src/canvas/index.ts
+++ b/packages/graph-plugins/src/canvas/index.ts
@@ -1,8 +1,8 @@
 import { MagicCanvasProps } from '@magic/canvas/types';
+import { CoreEventMap } from '@magic/graph-core/events';
+import { createThemeController } from '@magic/graph-plugins-shared/theme';
 import { createEventHub } from '@magic/graph-primitives/events/createEventHub';
 import { mergeEventHubs } from '@magic/graph-primitives/events/mergeEventHubs';
-import { createThemeController } from '@magic/graph-plugins-shared/theme';
-import { CoreEventMap } from '@magic/graph-core/events';
 import { useAnimatedShapes } from '@magic/shapes/animation/index';
 import { cross } from '@magic/shapes/shapes/cross/index';
 import { KeyboardEventEntries, MouseEventEntries } from '@magic/utils/types';
@@ -184,24 +184,22 @@ export const canvas =
       name: 'canvas',
       getters,
       controls: {
-        canvas: {
-          aggregator,
-          shapes,
+        aggregator,
+        shapes,
 
-          magicCanvas,
+        magicCanvas,
 
-          focused: canvasFocused,
-          hovered: useElementHover(magicCanvas.canvas),
+        focused: canvasFocused,
+        hovered: useElementHover(magicCanvas.canvas),
 
-          graphUnderCursor,
-          forceUpdateGraphUnderCursor,
+        graphUnderCursor,
+        forceUpdateGraphUnderCursor,
 
-          getNodePriority: () => getNodePriority,
+        getNodePriority: () => getNodePriority,
 
-          theme: {
-            ...theme,
-            detectors: createCanvasDetectors(theme._resolveToken),
-          },
+        theme: {
+          ...theme,
+          detectors: createCanvasDetectors(theme._resolveToken),
         },
       },
       actions,

--- a/packages/graph-plugins/src/canvas/index.ts
+++ b/packages/graph-plugins/src/canvas/index.ts
@@ -181,6 +181,7 @@ export const canvas =
       }).draw(ctx);
 
     return {
+      name: 'canvas',
       getters,
       controls: {
         canvas: {

--- a/packages/graph-plugins/src/canvas/types.ts
+++ b/packages/graph-plugins/src/canvas/types.ts
@@ -4,6 +4,7 @@ import { AnimatedShapeControls } from '@magic/shapes/animation/index';
 import { DeepReadonly } from 'ts-essentials';
 
 import { Ref, ShallowRef } from 'vue';
+
 import { AggregatorControls } from './aggregator/createAggregator.ts';
 import { CanvasElement } from './aggregator/types.ts';
 import { CanvasEventMap } from './events.ts';
@@ -60,6 +61,6 @@ type BaseCanvasControls = {
 export type CanvasControls = WithTheme<BaseCanvasControls, CanvasThemes>;
 
 export type CanvasPlugin = GraphPlugin<{
-  controls: { canvas: CanvasControls };
+  controls: CanvasControls;
   events: CanvasEventMap;
 }>;

--- a/packages/graph-plugins/src/canvas/types.ts
+++ b/packages/graph-plugins/src/canvas/types.ts
@@ -61,6 +61,7 @@ type BaseCanvasControls = {
 export type CanvasControls = WithTheme<BaseCanvasControls, CanvasThemes>;
 
 export type CanvasPlugin = GraphPlugin<{
+  name: 'canvas';
   controls: CanvasControls;
   events: CanvasEventMap;
 }>;

--- a/packages/graph-plugins/src/characteristics/index.ts
+++ b/packages/graph-plugins/src/characteristics/index.ts
@@ -38,6 +38,7 @@ export const characteristics: CharacteristicsPlugin = ({
   const sccs = useStronglyConnectedComponents(controls);
 
   return {
+    name: 'characteristics',
     actions,
     events,
     getters,

--- a/packages/graph-plugins/src/characteristics/index.ts
+++ b/packages/graph-plugins/src/characteristics/index.ts
@@ -2,6 +2,7 @@ import {
   GraphPlugin,
   PluginOptions,
 } from '@magic/graph-plugins-shared/plugins';
+
 import { AdjacencyListsPlugin } from '../adjacency-lists/types.ts';
 import {
   BidirectionalEdgesControls,
@@ -23,7 +24,7 @@ type CharacteristicsControls = {
 };
 
 type CharacteristicsPlugin = GraphPlugin<{
-  controls: { characteristics: CharacteristicsControls };
+  controls: CharacteristicsControls;
   dependsOn: [AdjacencyListsPlugin];
 }>;
 
@@ -43,14 +44,12 @@ export const characteristics: CharacteristicsPlugin = ({
     events,
     getters,
     controls: {
-      characteristics: {
-        complete: useComplete(controls),
-        cycles: useCycles(controls, sccs),
-        sccs: sccs,
-        bidirectionalEdges: useBidirectionalEdges(controls),
-        bipartite: useBipartite(controls),
-        connected: useConnected(controls),
-      },
+      complete: useComplete(controls),
+      cycles: useCycles(controls, sccs),
+      sccs: sccs,
+      bidirectionalEdges: useBidirectionalEdges(controls),
+      bipartite: useBipartite(controls),
+      connected: useConnected(controls),
     },
   };
 };

--- a/packages/graph-plugins/src/characteristics/index.ts
+++ b/packages/graph-plugins/src/characteristics/index.ts
@@ -24,6 +24,7 @@ type CharacteristicsControls = {
 };
 
 type CharacteristicsPlugin = GraphPlugin<{
+  name: 'characteristics';
   controls: CharacteristicsControls;
   dependsOn: [AdjacencyListsPlugin];
 }>;

--- a/packages/graph-plugins/src/focus/index.ts
+++ b/packages/graph-plugins/src/focus/index.ts
@@ -1,8 +1,8 @@
+import { CoreEventMap } from '@magic/graph-core/events';
+import { createThemeController } from '@magic/graph-plugins-shared/theme';
 import { createEventHub } from '@magic/graph-primitives/events/createEventHub';
 import { mergeEventHubs } from '@magic/graph-primitives/events/mergeEventHubs';
 import { ElementRemovalPayload } from '@magic/graph-primitives/transactions/types';
-import { createThemeController } from '@magic/graph-plugins-shared/theme';
-import { CoreEventMap } from '@magic/graph-core/events';
 import { nullThrows } from '@magic/utils/assert';
 import { getCtx } from '@magic/utils/ctx/index';
 import { MOUSE_BUTTONS } from '@magic/utils/mouse';
@@ -214,27 +214,25 @@ export const focus: FocusPlugin = ({
     actions: extendedActions,
     getters,
     controls: {
-      focus: {
-        set: setFocus,
-        clear: clearFocus,
-        add: addToFocus,
-        all: focusAll,
-        isFocused,
-        focusedElementIds: readonly(focusedElementIds),
-        focusedNodes: computed(() =>
-          controls.nodes.value.filter((node) => isFocused(node.id)),
-        ),
-        focusedEdges: computed(() =>
-          controls.edges.value.filter((edge) => isFocused(edge.id)),
-        ),
-        theme: {
-          ...theme,
-          detectors: createFocusDetectors(isFocused, theme._resolveToken),
-        },
-        lifecycle: {
-          enable,
-          disable,
-        },
+      set: setFocus,
+      clear: clearFocus,
+      add: addToFocus,
+      all: focusAll,
+      isFocused,
+      focusedElementIds: readonly(focusedElementIds),
+      focusedNodes: computed(() =>
+        controls.nodes.value.filter((node) => isFocused(node.id)),
+      ),
+      focusedEdges: computed(() =>
+        controls.edges.value.filter((edge) => isFocused(edge.id)),
+      ),
+      theme: {
+        ...theme,
+        detectors: createFocusDetectors(isFocused, theme._resolveToken),
+      },
+      lifecycle: {
+        enable,
+        disable,
       },
     },
     onAfterInit: () => {

--- a/packages/graph-plugins/src/focus/index.ts
+++ b/packages/graph-plugins/src/focus/index.ts
@@ -209,6 +209,7 @@ export const focus: FocusPlugin = ({
   const theme = createThemeController(createFocusThemeOverrides());
 
   return {
+    name: 'focus',
     events,
     actions: extendedActions,
     getters,

--- a/packages/graph-plugins/src/focus/types.ts
+++ b/packages/graph-plugins/src/focus/types.ts
@@ -72,6 +72,7 @@ export type FocusActions = {
 export type FocusControls = WithTheme<BaseFocusControls, FocusThemes>;
 
 export type FocusPlugin = GraphPlugin<{
+  name: 'focus';
   controls: WithLifecycle<FocusControls>;
   events: FocusEventMap;
   actions: FocusActions;

--- a/packages/graph-plugins/src/focus/types.ts
+++ b/packages/graph-plugins/src/focus/types.ts
@@ -1,7 +1,12 @@
-import { GraphPlugin, WithLifecycle, WithTheme } from '@magic/graph-plugins-shared/plugins';
+import {
+  GraphPlugin,
+  WithLifecycle,
+  WithTheme,
+} from '@magic/graph-plugins-shared/plugins';
 import { CoreEdge, CoreNode } from '@magic/graph-primitives/types';
 
 import { ComputedRef, Ref } from 'vue';
+
 import { CanvasPlugin } from '../canvas/types.ts';
 import { FocusEventMap } from './events.ts';
 import { FocusThemes } from './themes.ts';
@@ -67,7 +72,7 @@ export type FocusActions = {
 export type FocusControls = WithTheme<BaseFocusControls, FocusThemes>;
 
 export type FocusPlugin = GraphPlugin<{
-  controls: { focus: WithLifecycle<FocusControls> };
+  controls: WithLifecycle<FocusControls>;
   events: FocusEventMap;
   actions: FocusActions;
   dependsOn: [CanvasPlugin];

--- a/packages/graph-plugins/src/history/index.ts
+++ b/packages/graph-plugins/src/history/index.ts
@@ -1,6 +1,6 @@
+import { CoreEventMap } from '@magic/graph-core/events';
 import { createEventHub } from '@magic/graph-primitives/events/createEventHub';
 import { mergeEventHubs } from '@magic/graph-primitives/events/mergeEventHubs';
-import { CoreEventMap } from '@magic/graph-core/events';
 
 import { computed, ref } from 'vue';
 
@@ -78,21 +78,19 @@ export const history: HistoryPlugin = ({
     },
     events,
     controls: {
-      history: {
-        undo,
-        redo,
-        canUndo: computed(() => undoStack.value.length > 0),
-        canRedo: computed(() => redoStack.value.length > 0),
-        undoStack,
-        redoStack,
-        clearHistory,
-        lifecycle: {
-          enable: () => {
-            console.warn('not implemented');
-          },
-          disable: () => {
-            console.warn('not implemented');
-          },
+      undo,
+      redo,
+      canUndo: computed(() => undoStack.value.length > 0),
+      canRedo: computed(() => redoStack.value.length > 0),
+      undoStack,
+      redoStack,
+      clearHistory,
+      lifecycle: {
+        enable: () => {
+          console.warn('not implemented');
+        },
+        disable: () => {
+          console.warn('not implemented');
         },
       },
     },

--- a/packages/graph-plugins/src/history/index.ts
+++ b/packages/graph-plugins/src/history/index.ts
@@ -68,6 +68,7 @@ export const history: HistoryPlugin = ({
   };
 
   return {
+    name: 'history',
     getters,
     actions: {
       ...actions,

--- a/packages/graph-plugins/src/history/types.ts
+++ b/packages/graph-plugins/src/history/types.ts
@@ -48,6 +48,7 @@ type HistoryControls = {
 };
 
 export type HistoryPlugin = GraphPlugin<{
+  name: 'history';
   controls: WithLifecycle<HistoryControls>;
   events: HistoryEventMap;
   actions: HistoryActions;

--- a/packages/graph-plugins/src/history/types.ts
+++ b/packages/graph-plugins/src/history/types.ts
@@ -1,9 +1,10 @@
-import { ComputedRef, Ref } from 'vue';
-
 import {
   GraphPlugin,
   WithLifecycle,
 } from '@magic/graph-plugins-shared/plugins';
+
+import { ComputedRef, Ref } from 'vue';
+
 import { HistoryEventMap } from './events.ts';
 
 type HistoryOption = {
@@ -47,7 +48,7 @@ type HistoryControls = {
 };
 
 export type HistoryPlugin = GraphPlugin<{
-  controls: { history: WithLifecycle<HistoryControls> };
+  controls: WithLifecycle<HistoryControls>;
   events: HistoryEventMap;
   actions: HistoryActions;
   dependsOn: [];

--- a/packages/graph-plugins/src/marquee/index.ts
+++ b/packages/graph-plugins/src/marquee/index.ts
@@ -1,7 +1,7 @@
+import { CoreEventMap } from '@magic/graph-core/events';
+import { createThemeController } from '@magic/graph-plugins-shared/theme';
 import { createEventHub } from '@magic/graph-primitives/events/createEventHub';
 import { mergeEventHubs } from '@magic/graph-primitives/events/mergeEventHubs';
-import { createThemeController } from '@magic/graph-plugins-shared/theme';
-import { CoreEventMap } from '@magic/graph-core/events';
 import { normalizeBoundingBox } from '@magic/shapes/helpers';
 import type { BoundingBox, Coordinate } from '@magic/shapes/types/utility';
 import { MOUSE_BUTTONS } from '@magic/utils/mouse';
@@ -215,14 +215,12 @@ export const marquee: MarqueePlugin = ({
     actions,
     getters,
     controls: {
-      marquee: {
-        updateEncapsulatedNodeBox,
-        activelySelecting: computed(() => !!marqueeBox.value),
-        theme,
-        lifecycle: {
-          enable,
-          disable,
-        },
+      updateEncapsulatedNodeBox,
+      activelySelecting: computed(() => !!marqueeBox.value),
+      theme,
+      lifecycle: {
+        enable,
+        disable,
       },
     },
   };

--- a/packages/graph-plugins/src/marquee/index.ts
+++ b/packages/graph-plugins/src/marquee/index.ts
@@ -210,6 +210,7 @@ export const marquee: MarqueePlugin = ({
   enable();
 
   return {
+    name: 'marquee',
     events,
     actions,
     getters,

--- a/packages/graph-plugins/src/marquee/types.ts
+++ b/packages/graph-plugins/src/marquee/types.ts
@@ -26,6 +26,7 @@ type BaseMarqueeControls = {
 export type MarqueeControls = WithTheme<BaseMarqueeControls, MarqueeThemes>;
 
 export type MarqueePlugin = GraphPlugin<{
+  name: 'marquee';
   controls: WithLifecycle<MarqueeControls>;
   events: MarqueeEventMap;
   dependsOn: [CanvasPlugin, FocusPlugin];

--- a/packages/graph-plugins/src/marquee/types.ts
+++ b/packages/graph-plugins/src/marquee/types.ts
@@ -1,6 +1,11 @@
-import { GraphPlugin, WithLifecycle, WithTheme } from '@magic/graph-plugins-shared/plugins';
+import {
+  GraphPlugin,
+  WithLifecycle,
+  WithTheme,
+} from '@magic/graph-plugins-shared/plugins';
 
 import { ComputedRef } from 'vue';
+
 import { CanvasPlugin } from '../canvas/types.ts';
 import { FocusPlugin } from '../focus/types.ts';
 import { MarqueeEventMap } from './events.ts';
@@ -21,7 +26,7 @@ type BaseMarqueeControls = {
 export type MarqueeControls = WithTheme<BaseMarqueeControls, MarqueeThemes>;
 
 export type MarqueePlugin = GraphPlugin<{
-  controls: { marquee: WithLifecycle<MarqueeControls> };
+  controls: WithLifecycle<MarqueeControls>;
   events: MarqueeEventMap;
   dependsOn: [CanvasPlugin, FocusPlugin];
 }>;

--- a/packages/graph-plugins/src/node-drag/index.ts
+++ b/packages/graph-plugins/src/node-drag/index.ts
@@ -158,6 +158,7 @@ export const nodeDrag: NodeDragPlugin = ({
   enable();
 
   return {
+    name: 'nodeDrag',
     events,
     getters,
     actions,

--- a/packages/graph-plugins/src/node-drag/index.ts
+++ b/packages/graph-plugins/src/node-drag/index.ts
@@ -1,8 +1,8 @@
-import { createEventHub } from '@magic/graph-primitives/events/createEventHub';
-import { mergeEventHubs } from '@magic/graph-primitives/events/mergeEventHubs';
-import { createDragState } from '@magic/graph-plugins-shared/drag';
 import { CoreEventMap } from '@magic/graph-core/events';
 import { NodePositionStreamControls } from '@magic/graph-core/positions/types';
+import { createDragState } from '@magic/graph-plugins-shared/drag';
+import { createEventHub } from '@magic/graph-primitives/events/createEventHub';
+import { mergeEventHubs } from '@magic/graph-primitives/events/mergeEventHubs';
 import { nullThrows } from '@magic/utils/assert';
 import { MOUSE_BUTTONS } from '@magic/utils/mouse';
 import { DeepReadonly } from 'ts-essentials';
@@ -163,11 +163,9 @@ export const nodeDrag: NodeDragPlugin = ({
     getters,
     actions,
     controls: {
-      nodeDrag: {
-        lifecycle: {
-          enable,
-          disable,
-        },
+      lifecycle: {
+        enable,
+        disable,
       },
     },
   };

--- a/packages/graph-plugins/src/node-drag/types.ts
+++ b/packages/graph-plugins/src/node-drag/types.ts
@@ -21,6 +21,7 @@ export type ActiveDragNode = {
 };
 
 export type NodeDragPlugin = GraphPlugin<{
+  name: 'nodeDrag';
   controls: WithLifecycle<{}>;
   events: NodeDragEventMap;
   dependsOn: [CanvasPlugin];

--- a/packages/graph-plugins/src/node-drag/types.ts
+++ b/packages/graph-plugins/src/node-drag/types.ts
@@ -1,10 +1,10 @@
 import { Coordinate } from '@magic/canvas/types';
-import { CoreNode } from '@magic/graph-primitives/types';
-
 import {
   GraphPlugin,
   WithLifecycle,
 } from '@magic/graph-plugins-shared/plugins';
+import { CoreNode } from '@magic/graph-primitives/types';
+
 import { CanvasPlugin } from '../canvas/types.ts';
 import { FocusPlugin } from '../focus/types.ts';
 import { MarqueePlugin } from '../marquee/types.ts';
@@ -21,7 +21,7 @@ export type ActiveDragNode = {
 };
 
 export type NodeDragPlugin = GraphPlugin<{
-  controls: { nodeDrag: WithLifecycle<{}> };
+  controls: WithLifecycle<{}>;
   events: NodeDragEventMap;
   dependsOn: [CanvasPlugin];
   optionalDependsOn: [FocusPlugin, MarqueePlugin];

--- a/packages/graph-plugins/src/node-label/index.ts
+++ b/packages/graph-plugins/src/node-label/index.ts
@@ -47,6 +47,7 @@ export const nodeLabel: NodeLabelPlugin = ({
   enable();
 
   return {
+    name: 'nodeLabel',
     events,
     getters: {
       ...getters,

--- a/packages/graph-plugins/src/node-label/index.ts
+++ b/packages/graph-plugins/src/node-label/index.ts
@@ -75,17 +75,15 @@ export const nodeLabel: NodeLabelPlugin = ({
       // TODO add bulk additions and removals!
     },
     controls: {
-      nodeLabel: {
-        get: getNodeLabelWithAssert,
-        set: (label) => setNodeLabels([label]),
-        setMany: setNodeLabels,
-        lifecycle: {
-          enable,
-          disable,
-        },
-        _internal: {
-          nodeIdToLabel,
-        },
+      get: getNodeLabelWithAssert,
+      set: (label) => setNodeLabels([label]),
+      setMany: setNodeLabels,
+      lifecycle: {
+        enable,
+        disable,
+      },
+      _internal: {
+        nodeIdToLabel,
       },
     },
   };

--- a/packages/graph-plugins/src/node-label/types.ts
+++ b/packages/graph-plugins/src/node-label/types.ts
@@ -1,9 +1,9 @@
-import { MaybeGetter } from '@magic/utils/maybeGetter/index';
-
 import {
   GraphPlugin,
   WithLifecycle,
 } from '@magic/graph-plugins-shared/plugins';
+import { MaybeGetter } from '@magic/utils/maybeGetter/index';
+
 import { CanvasPlugin } from '../canvas/types.ts';
 import { FocusPlugin } from '../focus/types.ts';
 
@@ -43,7 +43,7 @@ type NodeLabelGetters = {
 };
 
 export type NodeLabelPlugin = GraphPlugin<{
-  controls: { nodeLabel: WithLifecycle<NodeLabelControls> };
+  controls: WithLifecycle<NodeLabelControls>;
   actions: NodeLabelActions;
   getters: NodeLabelGetters;
   dependsOn: [CanvasPlugin];

--- a/packages/graph-plugins/src/node-label/types.ts
+++ b/packages/graph-plugins/src/node-label/types.ts
@@ -43,6 +43,7 @@ type NodeLabelGetters = {
 };
 
 export type NodeLabelPlugin = GraphPlugin<{
+  name: 'nodeLabel';
   controls: WithLifecycle<NodeLabelControls>;
   actions: NodeLabelActions;
   getters: NodeLabelGetters;

--- a/packages/graph-plugins/src/transition-matrix/index.ts
+++ b/packages/graph-plugins/src/transition-matrix/index.ts
@@ -32,6 +32,7 @@ export const transitionMatrix: TransitionMatrixPlugin = ({
   controls,
   ...rest
 }) => ({
+  name: 'transitionMatrix',
   controls: {
     transitionMatrix: computed(() =>
       getTransitionMatrix(

--- a/packages/graph-plugins/src/transition-matrix/index.ts
+++ b/packages/graph-plugins/src/transition-matrix/index.ts
@@ -33,13 +33,11 @@ export const transitionMatrix: TransitionMatrixPlugin = ({
   ...rest
 }) => ({
   name: 'transitionMatrix',
-  controls: {
-    transitionMatrix: computed(() =>
-      getTransitionMatrix(
-        controls.adjacencyLists.weighted.value,
-        controls.nodeIdToIndex.value,
-      ),
+  controls: computed(() =>
+    getTransitionMatrix(
+      controls.adjacencyLists.weighted.value,
+      controls.nodeIdToIndex.value,
     ),
-  },
+  ),
   ...rest,
 });

--- a/packages/graph-plugins/src/transition-matrix/types.ts
+++ b/packages/graph-plugins/src/transition-matrix/types.ts
@@ -1,8 +1,8 @@
 import { CoreGetters } from '@magic/graph-core/getters';
+import { GraphPlugin } from '@magic/graph-plugins-shared/plugins';
 
 import { ComputedRef } from 'vue';
 
-import { GraphPlugin } from '@magic/graph-plugins-shared/plugins';
 import { AdjacencyListsPlugin } from '../adjacency-lists/types.ts';
 
 /**
@@ -12,6 +12,6 @@ import { AdjacencyListsPlugin } from '../adjacency-lists/types.ts';
 export type TransitionMatrix = CoreGetters['getEdge']['weight'][][];
 
 export type TransitionMatrixPlugin = GraphPlugin<{
-  controls: { transitionMatrix: ComputedRef<TransitionMatrix> };
+  controls: ComputedRef<TransitionMatrix>;
   dependsOn: [AdjacencyListsPlugin];
 }>;

--- a/packages/graph-plugins/src/transition-matrix/types.ts
+++ b/packages/graph-plugins/src/transition-matrix/types.ts
@@ -12,6 +12,7 @@ import { AdjacencyListsPlugin } from '../adjacency-lists/types.ts';
 export type TransitionMatrix = CoreGetters['getEdge']['weight'][][];
 
 export type TransitionMatrixPlugin = GraphPlugin<{
+  name: 'transitionMatrix';
   controls: ComputedRef<TransitionMatrix>;
   dependsOn: [AdjacencyListsPlugin];
 }>;

--- a/packages/graph-theme-presets/src/dark/index.ts
+++ b/packages/graph-theme-presets/src/dark/index.ts
@@ -1,5 +1,4 @@
 import { PluginThemes } from '@magic/graph-plugins-shared/plugins';
-import { ThemeForPlugin } from '@magic/graph-plugins-shared/plugins/internals/themes';
 import { CURSOR, CURSOR_FALLBACK } from '@magic/graph-plugins-shared/theme';
 import { AnchorsPlugin } from '@magic/graph-plugins/anchors/types';
 import { CanvasPlugin } from '@magic/graph-plugins/canvas/types';

--- a/packages/graph-theme-presets/src/dark/index.ts
+++ b/packages/graph-theme-presets/src/dark/index.ts
@@ -1,8 +1,6 @@
-import {
-  CURSOR,
-  CURSOR_FALLBACK,
-} from '@magic/graph-plugins-shared/theme';
 import { PluginThemes } from '@magic/graph-plugins-shared/plugins';
+import { ThemeForPlugin } from '@magic/graph-plugins-shared/plugins/internals/themes';
+import { CURSOR, CURSOR_FALLBACK } from '@magic/graph-plugins-shared/theme';
 import { AnchorsPlugin } from '@magic/graph-plugins/anchors/types';
 import { CanvasPlugin } from '@magic/graph-plugins/canvas/types';
 import { FocusPlugin } from '@magic/graph-plugins/focus/types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
     devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
-        version: 5.2.2(@vue/compiler-sfc@3.5.39)(prettier@3.9.1)
+        version: 5.2.2(@vue/compiler-sfc@3.5.39)(prettier@3.9.4)
       '@types/node':
         specifier: ^24.2.1
         version: 24.13.2
@@ -52,7 +52,7 @@ importers:
         version: 8.2.2
       prettier:
         specifier: ^3.4.2
-        version: 3.9.1
+        version: 3.9.4
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3
@@ -64,7 +64,7 @@ importers:
         version: 3.2.6(@types/node@24.13.2)(jiti@1.21.7)(jsdom@25.0.1)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))
       vue-tsc:
         specifier: ^3.0.7
-        version: 3.3.5(typescript@6.0.3)
+        version: 3.3.6(typescript@6.0.3)
 
   packages/canvas:
     dependencies:
@@ -132,7 +132,7 @@ importers:
         version: 9.1.2(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-storybook:
         specifier: ^9.0.1
-        version: 9.1.20(eslint@9.39.4(jiti@1.21.7))(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.1)(vite@5.4.21(@types/node@20.19.43)))(typescript@6.0.3)
+        version: 9.1.20(eslint@9.39.4(jiti@1.21.7))(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.4)(vite@5.4.21(@types/node@20.19.43)))(typescript@6.0.3)
       eslint-plugin-vue:
         specifier: ^9.32.0
         version: 9.33.0(eslint@9.39.4(jiti@1.21.7))
@@ -156,13 +156,13 @@ importers:
         version: 16.1.1(postcss@8.5.16)
       storybook:
         specifier: ^9.0.1
-        version: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.1)(vite@5.4.21(@types/node@20.19.43))
+        version: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.4)(vite@5.4.21(@types/node@20.19.43))
       tailwindcss:
         specifier: ^3.4.16
         version: 3.4.19
       typescript-eslint:
         specifier: ^8.17.0
-        version: 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+        version: 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       vite:
         specifier: ^5.3.1
         version: 5.4.21(@types/node@20.19.43)
@@ -409,7 +409,7 @@ importers:
     devDependencies:
       '@storybook/vue3-vite':
         specifier: ^9.0.1
-        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))(vue@3.5.39(typescript@5.9.3))
+        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))(vue@3.5.39(typescript@5.9.3))
       '@types/tinycolor2':
         specifier: 'catalog:'
         version: 1.4.6
@@ -418,7 +418,7 @@ importers:
         version: 5.2.4(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))(vue@3.5.39(typescript@5.9.3))
       storybook:
         specifier: ^9.0.1
-        version: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
+        version: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
       ts-essentials:
         specifier: ^10.2.0
         version: 10.2.1(typescript@5.9.3)
@@ -1536,63 +1536,63 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
-  '@typescript-eslint/eslint-plugin@8.62.0':
-    resolution: {integrity: sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==}
+  '@typescript-eslint/eslint-plugin@8.62.1':
+    resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.62.0
+      '@typescript-eslint/parser': ^8.62.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.62.0':
-    resolution: {integrity: sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.62.0':
-    resolution: {integrity: sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.62.0':
-    resolution: {integrity: sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.62.0':
-    resolution: {integrity: sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.62.0':
-    resolution: {integrity: sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==}
+  '@typescript-eslint/parser@8.62.1':
+    resolution: {integrity: sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.62.0':
-    resolution: {integrity: sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.62.0':
-    resolution: {integrity: sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==}
+  '@typescript-eslint/project-service@8.62.1':
+    resolution: {integrity: sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.62.0':
-    resolution: {integrity: sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==}
+  '@typescript-eslint/scope-manager@8.62.1':
+    resolution: {integrity: sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.62.1':
+    resolution: {integrity: sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.62.1':
+    resolution: {integrity: sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.62.0':
-    resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
+  '@typescript-eslint/types@8.62.1':
+    resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.62.1':
+    resolution: {integrity: sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.62.1':
+    resolution: {integrity: sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.62.1':
+    resolution: {integrity: sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-vue@5.2.4':
@@ -1742,8 +1742,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@3.3.5':
-    resolution: {integrity: sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==}
+  '@vue/language-core@3.3.6':
+    resolution: {integrity: sha512-LgBMZAy2sR3cQWknpyaxnI6yBkqDfLBPkbdhwRhQCvzfNJRQXPilgQIrdI/v4ytJ0sAq9bWhaPsjqBqneomJ3Q==}
 
   '@vue/reactivity@3.5.39':
     resolution: {integrity: sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==}
@@ -1910,8 +1910,8 @@ packages:
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -1950,8 +1950,8 @@ packages:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
 
-  caniuse-lite@1.0.30001799:
-    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+  caniuse-lite@1.0.30001800:
+    resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -2138,8 +2138,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.380:
-    resolution: {integrity: sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==}
+  electron-to-chromium@1.5.383:
+    resolution: {integrity: sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2998,8 +2998,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.9.1:
-    resolution: {integrity: sha512-ppiDo2CSwexck1eyZUwJHg/N3nf1+6IRCv7W/VJ5vaLnVCmB7+3CdRfMwoCHBBX6xTrREDTksZ4OZl5SSf4zXA==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -3464,8 +3464,8 @@ packages:
     resolution: {integrity: sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==}
     engines: {node: '>= 18'}
 
-  typescript-eslint@8.62.0:
-    resolution: {integrity: sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==}
+  typescript-eslint@8.62.1:
+    resolution: {integrity: sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -3673,8 +3673,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.5:
-    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
+  vue-component-type-helpers@3.3.6:
+    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -3697,8 +3697,8 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  vue-tsc@3.3.5:
-    resolution: {integrity: sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==}
+  vue-tsc@3.3.6:
+    resolution: {integrity: sha512-ERXGgbKSBGFUkavrJ1Iwj0ZVxKqB/5UOx65IXy7fPf2UsoI21n3ssQLwdvx8xyUGgJe9PvSZTM/FYzIdwUDPFA==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -4438,27 +4438,27 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
-  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))':
+  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
       ts-dedent: 2.3.0
       vite: 7.3.6(@types/node@24.13.2)(jiti@1.21.7)
 
-  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))':
+  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))':
     dependencies:
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/vue3-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))(vue@3.5.39(typescript@5.9.3))':
+  '@storybook/vue3-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
-      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
-      '@storybook/vue3': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vue@3.5.39(typescript@5.9.3))
+      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
+      '@storybook/vue3': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vue@3.5.39(typescript@5.9.3))
       find-package-json: 1.2.0
       magic-string: 0.30.21
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
       typescript: 5.9.3
       vite: 7.3.6(@types/node@24.13.2)(jiti@1.21.7)
       vue-component-meta: 2.2.12(typescript@5.9.3)
@@ -4466,13 +4466,13 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  '@storybook/vue3@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vue@3.5.39(typescript@5.9.3))':
+  '@storybook/vue3@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7))
       type-fest: 2.19.0
       vue: 3.5.39(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.5
+      vue-component-type-helpers: 3.3.6
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4498,7 +4498,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.39)(prettier@3.9.1)':
+  '@trivago/prettier-plugin-sort-imports@5.2.2(@vue/compiler-sfc@3.5.39)(prettier@3.9.4)':
     dependencies:
       '@babel/generator': 7.29.7
       '@babel/parser': 7.29.7
@@ -4506,7 +4506,7 @@ snapshots:
       '@babel/types': 7.29.7
       javascript-natural-sort: 0.7.1
       lodash: 4.18.1
-      prettier: 3.9.1
+      prettier: 3.9.4
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.39
     transitivePeerDependencies:
@@ -4585,14 +4585,14 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/type-utils': 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.62.0
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/type-utils': 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 9.39.4(jiti@1.21.7)
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -4601,41 +4601,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.62.0
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.62.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.62.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.1
       debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.62.0':
+  '@typescript-eslint/scope-manager@8.62.1':
     dependencies:
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/visitor-keys': 8.62.0
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
 
-  '@typescript-eslint/tsconfig-utils@8.62.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.62.1(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 9.39.4(jiti@1.21.7)
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -4643,14 +4643,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.62.0': {}
+  '@typescript-eslint/types@8.62.1': {}
 
-  '@typescript-eslint/typescript-estree@8.62.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.62.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/visitor-keys': 8.62.0
+      '@typescript-eslint/project-service': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
       semver: 7.8.5
@@ -4660,20 +4660,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.62.1
+      '@typescript-eslint/types': 8.62.1
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.62.0':
+  '@typescript-eslint/visitor-keys@8.62.1':
     dependencies:
-      '@typescript-eslint/types': 8.62.0
+      '@typescript-eslint/types': 8.62.1
       eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@20.19.43))(vue@3.5.39(typescript@6.0.3))':
@@ -4910,7 +4910,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/language-core@3.3.5':
+  '@vue/language-core@3.3.6':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.39
@@ -5035,7 +5035,7 @@ snapshots:
   autoprefixer@10.5.2(postcss@8.5.16):
     dependencies:
       browserslist: 4.28.4
-      caniuse-lite: 1.0.30001799
+      caniuse-lite: 1.0.30001800
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.16
@@ -5085,7 +5085,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5096,8 +5096,8 @@ snapshots:
   browserslist@4.28.4:
     dependencies:
       baseline-browser-mapping: 2.10.40
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.380
+      caniuse-lite: 1.0.30001800
+      electron-to-chromium: 1.5.383
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -5121,7 +5121,7 @@ snapshots:
 
   camelcase-css@2.0.1: {}
 
-  caniuse-lite@1.0.30001799: {}
+  caniuse-lite@1.0.30001800: {}
 
   chai@5.3.3:
     dependencies:
@@ -5287,7 +5287,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.380: {}
+  electron-to-chromium@1.5.383: {}
 
   emoji-regex@8.0.0: {}
 
@@ -5442,11 +5442,11 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@1.21.7)
 
-  eslint-plugin-storybook@9.1.20(eslint@9.39.4(jiti@1.21.7))(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.1)(vite@5.4.21(@types/node@20.19.43)))(typescript@6.0.3):
+  eslint-plugin-storybook@9.1.20(eslint@9.39.4(jiti@1.21.7))(storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.4)(vite@5.4.21(@types/node@20.19.43)))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       eslint: 9.39.4(jiti@1.21.7)
-      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.1)(vite@5.4.21(@types/node@20.19.43))
+      storybook: 9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.4)(vite@5.4.21(@types/node@20.19.43))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5991,7 +5991,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
@@ -6279,7 +6279,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.9.1: {}
+  prettier@3.9.4: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -6596,7 +6596,7 @@ snapshots:
 
   std-env@3.10.0: {}
 
-  storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.1)(vite@5.4.21(@types/node@20.19.43)):
+  storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@20.19.43)(typescript@6.0.3))(prettier@3.9.4)(vite@5.4.21(@types/node@20.19.43)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
@@ -6611,7 +6611,7 @@ snapshots:
       semver: 7.8.5
       ws: 8.21.0
     optionalDependencies:
-      prettier: 3.9.1
+      prettier: 3.9.4
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
@@ -6620,7 +6620,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)):
+  storybook@9.1.20(@testing-library/dom@10.4.1)(msw@2.14.6(@types/node@24.13.2)(typescript@5.9.3))(prettier@3.9.4)(vite@7.3.6(@types/node@24.13.2)(jiti@1.21.7)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.9.1
@@ -6635,7 +6635,7 @@ snapshots:
       semver: 7.8.5
       ws: 8.21.0
     optionalDependencies:
-      prettier: 3.9.1
+      prettier: 3.9.4
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil
@@ -6846,12 +6846,12 @@ snapshots:
 
   typed-function@4.2.2: {}
 
-  typescript-eslint@8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
+  typescript-eslint@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3))(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@9.39.4(jiti@1.21.7))(typescript@6.0.3)
       eslint: 9.39.4(jiti@1.21.7)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -7047,7 +7047,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.5: {}
+  vue-component-type-helpers@3.3.6: {}
 
   vue-docgen-api@4.79.2(vue@3.5.39(typescript@5.9.3)):
     dependencies:
@@ -7087,10 +7087,10 @@ snapshots:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.39(typescript@6.0.3)
 
-  vue-tsc@3.3.5(typescript@6.0.3):
+  vue-tsc@3.3.6(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.3.5
+      '@vue/language-core': 3.3.6
       typescript: 6.0.3
 
   vue@3.5.39(typescript@5.9.3):


### PR DESCRIPTION
Adds `name` as an explicit field on plugin results, flattens plugin controls, and moves namespacing into createGraph. Removes the runtime hack that inferred plugin name by inspecting the first key of controls.