### PR TITLE
feat: add `resolveUnderneath` support to theme token resolver

### DIFF
--- a/packages/graph-core/src/weights/createEdgeWeightStore.test.ts
+++ b/packages/graph-core/src/weights/createEdgeWeightStore.test.ts
@@ -2,13 +2,13 @@ import { createMockEventHub } from '@magic/graph-primitives/testing/events/creat
 import { Fraction } from 'mathjs';
 import { describe, expect, it } from 'vitest';
 
+import { createCoreEventRegistry } from '../events.ts';
 import { DEFAULT_GRAPH_SETTINGS } from '../settings/index.ts';
 import { DEFAULT_WEIGHT } from './constants.ts';
 import { createEdgeWeightStore } from './createEdgeWeightStore.ts';
-import { createEdgeWeightStoreEventRegistry } from './events.ts';
 
 const makeStore = (isGraphWeighted = true) => {
-  const hub = createMockEventHub(createEdgeWeightStoreEventRegistry());
+  const hub = createMockEventHub(createCoreEventRegistry());
   const settings = { value: { ...DEFAULT_GRAPH_SETTINGS, isGraphWeighted } };
   const store = createEdgeWeightStore(hub, settings as never);
   return { store, hub, settings };

--- a/packages/graph-core/src/weights/types.ts
+++ b/packages/graph-core/src/weights/types.ts
@@ -1,6 +1,6 @@
 import { CoreEdge } from '@magic/graph-primitives/types';
 import { MaybeGetter } from '@magic/utils/maybeGetter/index';
-import { Fraction } from 'mathjs';
+import type { Fraction } from 'mathjs';
 
 export type EdgeWeightEntry = {
   edgeId: CoreEdge['id'];

--- a/packages/graph-plugins-shared/src/theme/internals/createTokenResolver.ts
+++ b/packages/graph-plugins-shared/src/theme/internals/createTokenResolver.ts
@@ -15,43 +15,40 @@ export type TokenResolver<Themes> = <Token extends keyof Themes>(
 export const createTokenResolver = <Themes>(
   themeOverrides: ThemeOverrides<Themes>,
 ) => {
-  // internal helper: resolves a token using only overrides below `upperBound`.
-  // the bound is threaded explicitly through recursive calls (via `resolveBase`)
-  // rather than stored in shared closure state, so concurrent/unrelated
-  // resolutions on this same resolver instance can't corrupt one another.
   const resolveUpTo = <Token extends keyof Themes>(
     token: Token,
     upperBound: number,
     args: ThemeValueResolverArgs<Themes[Token]>,
   ): StyleValueFromThemeValue<Themes[Token]> => {
-    const argsList = (index: number) => {
-      const fn = () => resolveUpTo(token, index, args);
-      return [...args, fn];
-    };
-
-    // 1. get all the overrides we have stored for a given token, up to (but excluding) upperBound
+    // get all the overrides we have stored for a given token, up to (but excluding) upperBound
     const overrides = nullThrows(
       themeOverrides[token],
       `Theme overrides is missing entry for "${token.toString()}": Is "${token.toString()}" a valid token?`,
     ).slice(0, upperBound);
 
-    // 2. use the find last approach to get the override that was most recently registered
-    const winningIndex = overrides.findLastIndex((overrideItem, index) => {
+    let resolvedValue: StyleValueFromThemeValue<Themes[Token]> | undefined =
+      undefined;
+
+    // use the find last approach to get the override that was most recently registered
+    overrides.findLast((overrideItem, index) => {
       const themeValue = overrideItem.value;
-      const styleValue = getValue(themeValue, ...argsList(index));
-      return styleValue !== undefined;
+      const fullArgs = [...args, () => resolveUpTo(token, index, args)];
+      const styleValue = getValue(themeValue, ...fullArgs);
+      const isResolved = styleValue !== undefined;
+      if (isResolved) {
+        resolvedValue = styleValue as StyleValueFromThemeValue<Themes[Token]>;
+      }
+      return isResolved;
     });
 
-    // 4. the theme value for the token
-    const themeValue = nullThrows(
-      overrides[winningIndex]?.value,
-      `No theme value found for token "${token.toString()}": Is "${token.toString()}" a valid token?`,
-    );
+    // if there is no resolved value it means that a token is not mapped to a style, which should never happen!
+    if (resolvedValue === undefined) {
+      throw new Error(
+        `No theme value found for token "${token.toString()}": Is "${token.toString()}" a valid token?`,
+      );
+    }
 
-    // 5. combine the theme value with the token resolution args to get the final resolved style value.
-    // resolveBase for this call must see only overrides below the winning one, not the outer upperBound
-    // (which would re-select this same override and recurse forever).
-    return getValue(themeValue as any, ...argsList(winningIndex));
+    return resolvedValue;
   };
 
   const resolver: TokenResolver<Themes> = (token, ...args) =>

--- a/packages/graph-plugins-shared/src/theme/internals/createTokenResolver.ts
+++ b/packages/graph-plugins-shared/src/theme/internals/createTokenResolver.ts
@@ -20,6 +20,13 @@ export const createTokenResolver = <Themes>(
     upperBound: number,
     args: ThemeValueResolverArgs<Themes[Token]>,
   ): StyleValueFromThemeValue<Themes[Token]> => {
+    // upperBound at zero means we're at the preset layer so there's nothing beneath it to resolve
+    if (upperBound === 0) {
+      throw new Error(
+        `resolveUnderneath was invoked for token "${token.toString()}" with nothing beneath it.`,
+      );
+    }
+
     // get all the overrides we have stored for a given token, up to (but excluding) upperBound
     const overrides = nullThrows(
       themeOverrides[token],

--- a/packages/graph-plugins-shared/src/theme/internals/createTokenResolver.ts
+++ b/packages/graph-plugins-shared/src/theme/internals/createTokenResolver.ts
@@ -12,28 +12,50 @@ export type TokenResolver<Themes> = <Token extends keyof Themes>(
   ...args: ThemeValueResolverArgs<Themes[Token]>
 ) => StyleValueFromThemeValue<Themes[Token]>;
 
-export const createTokenResolver =
-  <Themes>(themeOverrides: ThemeOverrides<Themes>): TokenResolver<Themes> =>
-  (token, ...args) => {
-    // 1. get all the overrides we have stored for a given token
+export const createTokenResolver = <Themes>(
+  themeOverrides: ThemeOverrides<Themes>,
+) => {
+  // internal helper: resolves a token using only overrides below `upperBound`.
+  // the bound is threaded explicitly through recursive calls (via `resolveBase`)
+  // rather than stored in shared closure state, so concurrent/unrelated
+  // resolutions on this same resolver instance can't corrupt one another.
+  const resolveUpTo = <Token extends keyof Themes>(
+    token: Token,
+    upperBound: number,
+    args: ThemeValueResolverArgs<Themes[Token]>,
+  ): StyleValueFromThemeValue<Themes[Token]> => {
+    const argsList = (index: number) => {
+      const fn = () => resolveUpTo(token, index, args);
+      return [...args, fn];
+    };
+
+    // 1. get all the overrides we have stored for a given token, up to (but excluding) upperBound
     const overrides = nullThrows(
       themeOverrides[token],
       `Theme overrides is missing entry for "${token.toString()}": Is "${token.toString()}" a valid token?`,
-    );
+    ).slice(0, upperBound);
 
     // 2. use the find last approach to get the override that was most recently registered
-    const override = overrides.findLast((overrideItem) => {
+    const winningIndex = overrides.findLastIndex((overrideItem, index) => {
       const themeValue = overrideItem.value;
-      const styleValue = getValue(themeValue, ...args);
+      const styleValue = getValue(themeValue, ...argsList(index));
       return styleValue !== undefined;
     });
 
     // 4. the theme value for the token
     const themeValue = nullThrows(
-      override?.value,
+      overrides[winningIndex]?.value,
       `No theme value found for token "${token.toString()}": Is "${token.toString()}" a valid token?`,
     );
 
-    // 5. combine the theme value with the token resolution args to get the final resolved style value
-    return getValue(themeValue as any, ...args);
+    // 5. combine the theme value with the token resolution args to get the final resolved style value.
+    // resolveBase for this call must see only overrides below the winning one, not the outer upperBound
+    // (which would re-select this same override and recurse forever).
+    return getValue(themeValue as any, ...argsList(winningIndex));
   };
+
+  const resolver: TokenResolver<Themes> = (token, ...args) =>
+    resolveUpTo(token, themeOverrides[token].length, args);
+
+  return resolver;
+};

--- a/packages/graph-plugins-shared/src/theme/internals/types.ts
+++ b/packages/graph-plugins-shared/src/theme/internals/types.ts
@@ -20,11 +20,14 @@ import { AnyFunction } from 'ts-essentials';
  */
 export type ThemeValue<StyleValue, ResolverArgs extends unknown[] = []> =
   | StyleValue
-  | ((...args: ResolverArgs) => StyleValue | void);
+  | ((
+      ...args: [...ResolverArgs, resolveBase: () => StyleValue]
+    ) => StyleValue | void);
 
-export type ThemeValueResolverArgs<ThemeValue> = Parameters<
-  Extract<ThemeValue, AnyFunction>
->;
+export type ThemeValueResolverArgs<ThemeValue> =
+  Parameters<Extract<ThemeValue, AnyFunction>> extends [...infer F, infer _]
+    ? F
+    : never;
 
 export type StyleValueFromThemeValue<Value> =
   Value extends ThemeValue<infer StyleValue, infer _> ? StyleValue : never;

--- a/packages/graph-plugins-shared/src/theme/internals/types.ts
+++ b/packages/graph-plugins-shared/src/theme/internals/types.ts
@@ -21,7 +21,7 @@ import { AnyFunction } from 'ts-essentials';
 export type ThemeValue<StyleValue, ResolverArgs extends unknown[] = []> =
   | StyleValue
   | ((
-      ...args: [...ResolverArgs, resolveBase: () => StyleValue]
+      ...args: [...ResolverArgs, resolveUnderneath: () => StyleValue]
     ) => StyleValue | void);
 
 export type ThemeValueResolverArgs<ThemeValue> =

--- a/packages/graph-plugins/src/anchors/themes.ts
+++ b/packages/graph-plugins/src/anchors/themes.ts
@@ -1,10 +1,10 @@
-import { CoreNode } from '@magic/graph-primitives/types';
 import {
   Cursor,
   CursorFallback,
   ThemeOverrides,
   ThemeValue,
 } from '@magic/graph-plugins-shared/theme';
+import { CoreNode } from '@magic/graph-primitives/types';
 import { Color } from '@magic/utils/colors';
 
 import { NodeAnchor } from './types.ts';

--- a/packages/graph-plugins/src/canvas/index.ts
+++ b/packages/graph-plugins/src/canvas/index.ts
@@ -211,6 +211,10 @@ export const canvas =
         weightLayer.set('edge.default.text.content', (edge) =>
           getters.getEdge(edge.id).weight.toFraction(),
         );
+        weightLayer.set('node.default.text.color', (_, r) => {
+          console.log(r());
+          return 'red';
+        });
       },
     };
   };

--- a/packages/graph-plugins/src/canvas/index.ts
+++ b/packages/graph-plugins/src/canvas/index.ts
@@ -211,10 +211,6 @@ export const canvas =
         weightLayer.set('edge.default.text.content', (edge) =>
           getters.getEdge(edge.id).weight.toFraction(),
         );
-        weightLayer.set('node.default.text.color', (_, r) => {
-          console.log(r());
-          return 'red';
-        });
       },
     };
   };

--- a/packages/products/src/markov-chains/sim/theme.ts
+++ b/packages/products/src/markov-chains/sim/theme.ts
@@ -23,18 +23,11 @@ export const useSimulationTheme = (
     return traceAtStep.value[index].simplify(0.001).toFraction();
   };
 
-  const nodeTextSize = ({ id }: { id: string }) => {
-    const preset = graph.theme.activePreset();
-    const defaultSize = getValue(preset.canvas['node.default.text.size'], {
-      id,
-    })!;
-    if (graph.focus.isFocused(id)) return;
-    return defaultSize - 5;
-  };
-
   const theme = () => {
     set('node.default.text.content', nodeText);
-    set('node.default.text.size', nodeTextSize);
+    set('node.default.text.size', (_, resolveUnderneath) => {
+      return resolveUnderneath() - 5;
+    });
   };
 
   const untheme = () => {

--- a/packages/products/src/markov-chains/ui/useMarkovColorizer.ts
+++ b/packages/products/src/markov-chains/ui/useMarkovColorizer.ts
@@ -1,5 +1,3 @@
-import { getValue } from '@magic/utils/maybeGetter/index';
-
 import { useSCCColorizer } from '../../sandbox/ui/GraphInfoMenu/useSCCColorizer.ts';
 import type { Graph } from '../../shared/useGraphWithCanvas.ts';
 import { USETHEME_ID } from '../constants.ts';

--- a/packages/products/src/markov-chains/ui/useMarkovColorizer.ts
+++ b/packages/products/src/markov-chains/ui/useMarkovColorizer.ts
@@ -11,25 +11,18 @@ export const useMarkovColorizer = (graph: Graph, markov: MarkovChain) => {
   const canvas = graph.canvas.theme.createLayer(USETHEME_ID);
   const anchors = graph.anchors.theme.createLayer(USETHEME_ID);
 
-  const colorNodeBorder = (node: { id: string }) => {
-    const preset = graph.theme.activePreset();
-    const focusBorderColor = getValue(
-      preset.focus['node.focus.border.color'],
-      node,
-    )!;
-    const defaultBorderColor = getValue(
-      preset.canvas['node.default.border.color'],
-      node,
-    )!;
-
-    if (graph.focus.isFocused(node.id)) return focusBorderColor;
-    if (markov.transientStates.value.has(node.id)) return defaultBorderColor;
+  const fallbackIfTransient = (
+    node: { id: string },
+    resolveUnderneath: () => string,
+  ) => {
+    const isTransient = markov.transientStates.value.has(node.id);
+    if (isTransient) return resolveUnderneath();
   };
 
   const colorize = () => {
     sccColorizer.color();
-    canvas.set('node.default.border.color', colorNodeBorder);
-    anchors.set('anchors.default.color', colorNodeBorder);
+    canvas.set('node.default.border.color', fallbackIfTransient);
+    anchors.set('anchors.default.color', fallbackIfTransient);
   };
 
   const decolorize = () => {

--- a/packages/products/src/min-spanning-tree/sim/theme.ts
+++ b/packages/products/src/min-spanning-tree/sim/theme.ts
@@ -1,9 +1,6 @@
-import { getValue } from '@magic/utils/maybeGetter/index';
-
 import { computed } from 'vue';
 
 import type { SimulationControls } from '../../shared/ui/general/sim/types.ts';
-import { GEdge } from '../../shared/useGraph.ts';
 import type { Graph } from '../../shared/useGraphWithCanvas.ts';
 import type { MSTTrace } from './runner.ts';
 
@@ -23,35 +20,16 @@ export const useSimulationTheme = (
 
   const mstAtStep = computed(() => trace.value.slice(0, sim.step.value));
 
-  const colorEdge = (edge: Omit<GEdge, 'weight'>) => {
-    if (graph.focus.isFocused(edge.id)) return;
-
-    const color = getValue(
-      graph.theme.activePreset().canvas['edge.default.color'],
-      edge,
-    )!;
-
+  const dimIfNotInMST = (edge: { id: string }, baseResolver: () => string) => {
+    const color = baseResolver();
     const inMST = mstAtStep.value.some((e) => e.id === edge.id);
     if (inMST) return color;
-    else return color + DIM_FACTOR;
-  };
-
-  const colorEdgeText = (edge: Omit<GEdge, 'weight'>) => {
-    if (graph.focus.isFocused(edge.id)) return;
-
-    const color = getValue(
-      graph.theme.activePreset().canvas['edge.default.text.color'],
-      edge,
-    )!;
-
-    const inMST = mstAtStep.value.some((e) => e.id === edge.id);
-    if (inMST) return color;
-    else return color + DIM_FACTOR;
+    return color + DIM_FACTOR;
   };
 
   const activate = () => {
-    set('edge.default.color', colorEdge);
-    set('edge.default.text.color', colorEdgeText);
+    set('edge.default.color', dimIfNotInMST);
+    set('edge.default.text.color', dimIfNotInMST);
   };
 
   const deactivate = () => {

--- a/packages/products/src/shared/ui/graph-core/GNode.vue
+++ b/packages/products/src/shared/ui/graph-core/GNode.vue
@@ -24,12 +24,14 @@
     graph.value.focus.set([props.node.id]);
   };
 
-  const updateTheme = setInterval(() => {
+  const updateTheme = () => {
     theme.value = graph.value.theme.resolveNodeStyles(props.node);
-  }, 100);
+  };
+
+  graph.value.events.subscribe('onDraw', updateTheme);
 
   onUnmounted(() => {
-    clearInterval(updateTheme);
+    graph.value.events.unsubscribe('onDraw', updateTheme);
   });
 </script>
 

--- a/packages/products/src/shared/ui/graph-core/GNode.vue
+++ b/packages/products/src/shared/ui/graph-core/GNode.vue
@@ -53,7 +53,7 @@
     }"
   >
     <slot>
-      {{ theme.text }}
+      {{ theme.text.content }}
     </slot>
   </div>
 </template>


### PR DESCRIPTION
closes #722

Theme overrides can call resolveUnderneath() to fall back to the layer beneath them instead of re-deriving it manually. Migrates Markov and MST themes to this pattern; throws if called from the preset layer, where nothing exists beneath.